### PR TITLE
Fix various compiler warnings

### DIFF
--- a/container_window.cpp
+++ b/container_window.cpp
@@ -51,12 +51,12 @@ namespace uih {
         if (msg == WM_NCCREATE) {
             auto create_params = reinterpret_cast<LPVOID *>(reinterpret_cast<CREATESTRUCT *>(lp)->lpCreateParams);
             p_this = reinterpret_cast<ContainerWindow*>(create_params[0]);
-            SetWindowLongPtr(wnd, GWL_USERDATA, reinterpret_cast<LPARAM>(p_this));
+            SetWindowLongPtr(wnd, GWLP_USERDATA, reinterpret_cast<LPARAM>(p_this));
         } else
-            p_this = reinterpret_cast<ContainerWindow*>(GetWindowLongPtr(wnd, GWL_USERDATA));
+            p_this = reinterpret_cast<ContainerWindow*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
 
         if (msg == WM_NCDESTROY)
-        SetWindowLongPtr(wnd, GWL_USERDATA, reinterpret_cast<LPARAM>(nullptr));
+        SetWindowLongPtr(wnd, GWLP_USERDATA, reinterpret_cast<LPARAM>(nullptr));
 
         return p_this ? p_this->on_message(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);
     }

--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -41,12 +41,12 @@ namespace uih {
         class Column {
         public:
             pfc::string8 m_title;
-            t_size m_size;
-            t_size m_display_size;
-            t_size m_autosize_weight;
+            int m_size;
+            int m_display_size;
+            int m_autosize_weight;
             uih::alignment m_alignment;
 
-            Column(const char* title, t_size cx, t_size p_autosize_weight = 1, uih::alignment alignment = uih::ALIGN_LEFT)
+            Column(const char* title, int cx, int p_autosize_weight = 1, uih::alignment alignment = uih::ALIGN_LEFT)
                 : m_title(title), m_size(cx), m_display_size(cx), m_autosize_weight(p_autosize_weight),
                 m_alignment(alignment) {};
 
@@ -198,7 +198,7 @@ namespace uih {
 
         unsigned calculate_header_height();
         void set_columns(const pfc::list_base_const_t<Column>& columns);
-        void set_column_widths(const pfc::list_base_const_t<t_size>& widths);
+        void set_column_widths(const pfc::list_base_const_t<int>& widths);
         void set_group_count(t_size count, bool b_update_columns = true);
 
         t_size get_group_count() const
@@ -206,18 +206,18 @@ namespace uih {
             return m_group_count;
         }
 
-        t_size get_columns_width();
-        t_size get_columns_display_width();
-        t_size get_column_display_width(t_size index);
+        int get_columns_width();
+        int get_columns_display_width();
+        int get_column_display_width(t_size index);
         uih::alignment get_column_alignment(t_size index);
         t_size get_column_count();
 
-        void _set_scroll_position(t_size val)
+        void _set_scroll_position(int val)
         {
             m_scroll_position = val;
         }
 
-        t_size _get_scroll_position() const
+        int _get_scroll_position() const
         {
             return m_scroll_position;
         }
@@ -329,7 +329,7 @@ namespace uih {
         void get_items_rect(LPRECT rc);
         void get_items_size(LPRECT rc);
 
-        t_size get_items_top()
+        int get_items_top()
         {
             RECT rc;
             get_items_rect(&rc);
@@ -352,21 +352,21 @@ namespace uih {
         void reorder_items_partial(size_t base, const size_t * order, size_t count, bool update_focus_item = true,
             bool update_display = true);
 
-        t_size get_previous_item(t_size y, bool b_include_headers = false);
-        t_size get_next_item(t_size y, bool b_include_headers = false);
+        t_size get_previous_item(int y, bool b_include_headers = false);
+        t_size get_next_item(int y, bool b_include_headers = false);
         t_size get_last_viewable_item();
         t_size get_last_item();
         int get_default_item_height();
         int get_default_group_height();
 
-        t_size get_item_height() const
+        int get_item_height() const
         {
             return m_item_height;
         }
 
-        t_size get_item_height(t_size index) const
+        int get_item_height(t_size index) const
         {
-            t_size ret = 1;
+            int ret = 1;
             if (m_variable_height_items && index < m_items.get_count())
                 ret = m_items[index]->m_line_count * get_item_height();
             else
@@ -379,36 +379,36 @@ namespace uih {
             m_items.remove_all();
         }
 
-        t_size get_item_position(t_size index, bool b_include_headers = false)
+        int get_item_position(t_size index, bool b_include_headers = false)
         {
-            t_size ret = 0;
+            int ret = 0;
             if (index < m_items.get_count())
                 ret = m_items[index]->m_display_position;
             return ret;
         }
 
-        t_size get_item_position_bottom(t_size index, bool b_include_headers = false)
+        int get_item_position_bottom(t_size index, bool b_include_headers = false)
         {
             return get_item_position(index, b_include_headers) + get_item_height(index);
         }
 
-        t_size get_group_minimum_inner_height()
+        int get_group_minimum_inner_height()
         {
             return get_show_group_info_area() ? get_group_info_area_total_height() : 0;
         }
 
-        t_size get_item_group_bottom(t_size index, bool b_include_headers = false)
+        int get_item_group_bottom(t_size index, bool b_include_headers = false)
         {
             t_size gstart = index, gcount = 0;
             get_item_group(index, m_group_count ? m_group_count - 1 : 0, gstart, gcount);
-            t_size ret = 0;
+            int ret = 0;
             if (gcount)
                 index = gstart + gcount - 1;
             ret += get_item_position(index, b_include_headers);
             ret += m_item_height - 1;
             if (get_show_group_info_area() && m_group_count) {
-                t_size gheight = gcount * m_item_height;
-                t_size group_cy = get_group_info_area_total_height();
+                int gheight = gcount * m_item_height;
+                int group_cy = get_group_info_area_total_height();
                 if (gheight < group_cy)
                     ret += group_cy - gheight;
             }
@@ -576,7 +576,7 @@ namespace uih {
 
         virtual void notify_on_kill_focus(HWND wnd_receiving) {};
 
-        virtual void notify_on_column_size_change(t_size index, t_size new_width) {};
+        virtual void notify_on_column_size_change(t_size index, int new_width) {};
 
         virtual void notify_on_group_info_area_size_change(t_size new_width) {};
 
@@ -679,10 +679,10 @@ namespace uih {
             //FIXME set after creation?
         }
 
-        t_size get_item_indentation();
-        t_size get_default_indentation_step();
+        int get_item_indentation();
+        int get_default_indentation_step();
 
-        void set_group_info_area_size(t_size width, t_size height)
+        void set_group_info_area_size(int width, int height)
         {
             m_group_info_area_width = width;
             m_group_info_area_height = height;
@@ -693,22 +693,22 @@ namespace uih {
             }
         }
 
-        t_size get_group_info_area_width()
+        int get_group_info_area_width()
         {
             return get_show_group_info_area() ? m_group_info_area_width : 0;
         }
 
-        t_size get_group_info_area_height()
+        int get_group_info_area_height()
         {
             return get_show_group_info_area() ? m_group_info_area_height : 0;
         }
 
-        t_size get_group_info_area_total_width()
+        int get_group_info_area_total_width()
         {
             return get_show_group_info_area() ? m_group_info_area_width + get_default_indentation_step() : 0;
         }
 
-        t_size get_group_info_area_total_height()
+        int get_group_info_area_total_height()
         {
             return get_show_group_info_area() ? m_group_info_area_height + get_default_indentation_step() : 0;
         }
@@ -747,7 +747,7 @@ namespace uih {
             return m_group_count ? m_show_group_info_area : false;
         }
 
-        t_size get_total_indentation()
+        int get_total_indentation()
         {
             return get_item_indentation() + get_group_info_area_total_width();
         }
@@ -759,14 +759,14 @@ namespace uih {
         COLORREF get_group_text_colour_default();
         bool get_group_text_colour_default(COLORREF& cr);
 
-        void render_group_default(const ColourData& p_data, HDC dc, const char* text, t_size indentation, t_size level, const RECT& rc);
-        void render_item_default(const ColourData& p_data, HDC dc, t_size index, t_size indentation, bool b_selected, bool b_window_focused, bool b_highlight, bool b_focused, const RECT* rc);
+        void render_group_default(const ColourData& p_data, HDC dc, const char* text, int indentation, t_size level, const RECT& rc);
+        void render_item_default(const ColourData& p_data, HDC dc, t_size index, int indentation, bool b_selected, bool b_window_focused, bool b_highlight, bool b_focused, const RECT* rc);
         void render_background_default(const ColourData& p_data, HDC dc, const RECT* rc);
 
         virtual void render_group_info(HDC dc, t_size index, t_size group_count, const RECT& rc) {};
 
-        virtual void render_group(HDC dc, t_size index, t_size group, const char* text, t_size indentation, t_size level, const RECT& rc);
-        virtual void render_item(HDC dc, t_size index, t_size indentation, bool b_selected, bool b_window_focused, bool b_highlight, bool b_focused, const RECT* rc);
+        virtual void render_group(HDC dc, t_size index, t_size group, const char* text, int indentation, t_size level, const RECT& rc);
+        virtual void render_item(HDC dc, t_size index, int indentation, bool b_selected, bool b_window_focused, bool b_highlight, bool b_focused, const RECT* rc);
         virtual void render_background(HDC dc, const RECT* rc);
         virtual bool render_drag_image(LPSHDRAGIMAGE lpsdi);
 
@@ -841,7 +841,7 @@ namespace uih {
 
         LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
-        void render_items(HDC dc, const RECT& rc_update, t_size cx);
+        void render_items(HDC dc, const RECT& rc_update, int cx);
         void __insert_items_v3(t_size index_start, t_size count, const InsertItem* items);
         void __replace_items_v2(t_size index_start, t_size count, const InsertItem* items);
         void __remove_item(t_size index);
@@ -883,7 +883,7 @@ namespace uih {
         void create_tooltip(/*t_size index, t_size column, */const char* str);
         void destroy_tooltip();
         bool is_item_clipped(t_size index, t_size column);
-        t_size get_text_width(const char* text, t_size length);
+        int get_text_width(const char* text, t_size length);
 
         gdi_object_t<HFONT>::ptr_t m_font, m_font_header, m_group_font;
 
@@ -921,8 +921,8 @@ namespace uih {
         int m_scroll_position{0};
         int m_horizontal_scroll_position{0};
         t_size m_group_count{0};
-        t_size m_item_height{1};
-        t_size m_group_height{1};
+        int m_item_height{1};
+        int m_group_height{1};
         t_size m_shift_start{std::numeric_limits<t_size>::max()};
         bool m_timer_scroll_up{false};
         bool m_timer_scroll_down{false};
@@ -965,8 +965,8 @@ namespace uih {
         bool m_alternate_selection{false};
         bool m_allow_header_rearrange{false};
 
-        t_size m_group_info_area_width{0};
-        t_size m_group_info_area_height{0};
+        int m_group_info_area_width{0};
+        int m_group_info_area_height{0};
         bool m_show_group_info_area{false};
         bool m_have_indent_column{false};
 

--- a/list_view/list_view_columns.cpp
+++ b/list_view/list_view_columns.cpp
@@ -2,23 +2,25 @@
 
 namespace uih {
 
-    t_size ListView::get_columns_width()
+    int ListView::get_columns_width()
     {
-        t_size i, count = m_columns.get_count(), ret = 0;
+        t_size i, count = m_columns.get_count();
+        int ret = 0;
         for (i = 0; i < count; i++)
             ret += m_columns[i].m_size;
         return ret;
     }
-    t_size ListView::get_columns_display_width()
+    int ListView::get_columns_display_width()
     {
-        t_size i, count = m_columns.get_count(), ret = 0;
+        t_size i, count = m_columns.get_count();
+        int ret = 0;
         for (i = 0; i < count; i++)
             ret += m_columns[i].m_display_size;
         return ret;
     }
-    t_size ListView::get_column_display_width(t_size index)
+    int ListView::get_column_display_width(t_size index)
     {
-        t_size ret = 0;
+        int ret = 0;
         assert(index < get_column_count());
         if (index < get_column_count())
             ret = m_columns[index].m_display_size;
@@ -52,7 +54,7 @@ namespace uih {
         }
     }
 
-    void ListView::set_column_widths(const pfc::list_base_const_t<t_size> & widths)
+    void ListView::set_column_widths(const pfc::list_base_const_t<int> & widths)
     {
         t_size i, count = m_columns.get_count();
         for (i = 0; i < count; i++)
@@ -73,7 +75,7 @@ namespace uih {
         //console::formatter() << "get_column_sizes";
         RECT rc;
         get_items_rect(&rc);
-        t_size display_width = RECT_CX(rc), width = get_columns_width(), total_weight = 0, indent = get_total_indentation();
+        int display_width = RECT_CX(rc), width = get_columns_width(), total_weight = 0, indent = get_total_indentation();
         if (display_width > indent) display_width -= indent;
         else display_width = 0;
         t_size i, count = p_out.get_count();
@@ -98,7 +100,7 @@ namespace uih {
             {
                 //console::formatter() << "width_difference: " << width_difference << " total_weight: " << total_weight << " sized_count: " << sized_count;
                 t_ssize width_difference_local = width_difference;
-                t_size total_weight_local = total_weight;
+                int total_weight_local = total_weight;
                 for (i = 0; i < count; i++)
                 {
                     if (!sized[i] && total_weight_local)

--- a/list_view/list_view_header.cpp
+++ b/list_view/list_view_header.cpp
@@ -81,7 +81,7 @@ namespace uih {
 
             {
                 int n,t=m_columns.get_count(),i=0;
-                t_size indentation = get_total_indentation();
+                const auto indentation = get_total_indentation();
                 if (indentation/*m_group_count*/)
                 {
                     hdi.fmt = HDF_STRING | HDF_LEFT ; 

--- a/list_view/list_view_hittest.cpp
+++ b/list_view/list_view_hittest.cpp
@@ -9,7 +9,7 @@ namespace uih {
         t_size k, kcount = m_columns.get_count(); t_ssize colcu = x_left_items;
         for (k = 0; k < kcount; k++)
         {
-            t_size end = colcu + m_columns[k].m_display_size;
+            int end = colcu + m_columns[k].m_display_size;
             if (pt_client.x >= colcu && pt_client.x < end)
                 result.column = k;
             colcu = end;
@@ -120,7 +120,7 @@ namespace uih {
         RECT rc;
         get_items_size(&rc);
         t_size ret = get_previous_item(rc.bottom + m_scroll_position);
-        if (get_item_position(ret) + get_item_height(ret) > (t_size)rc.bottom + m_scroll_position) ret--;
+        if (get_item_position(ret) + get_item_height(ret) > rc.bottom + m_scroll_position) ret--;
         return ret;
     }
     t_size ListView::get_last_item()
@@ -130,7 +130,7 @@ namespace uih {
         t_size ret = get_previous_item(rc.bottom + m_scroll_position);
         return ret;
     }
-    t_size ListView::get_previous_item(t_size y, bool b_include_headers)
+    t_size ListView::get_previous_item(int y, bool b_include_headers)
     {
         {
             t_size max = m_items.get_count();
@@ -153,7 +153,7 @@ namespace uih {
             //return true;
         }
     }
-    t_size ListView::get_next_item(t_size y, bool b_include_headers)
+    t_size ListView::get_next_item(int y, bool b_include_headers)
     {
         {
             t_size max = m_items.get_count();

--- a/list_view/list_view_inline_edit.cpp
+++ b/list_view/list_view_inline_edit.cpp
@@ -57,7 +57,7 @@ namespace uih {
         ListView * p_this;
         LRESULT rv;
 
-        p_this = reinterpret_cast<ListView*>(GetWindowLongPtr(wnd, GWL_USERDATA));
+        p_this = reinterpret_cast<ListView*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
 
         rv = p_this ? p_this->on_inline_edit_message(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);;
 
@@ -236,8 +236,8 @@ namespace uih {
             }
             else
             {
-                target = get_item_position(indices[0]) > (t_size)m_scroll_position ? indices[indices_count - 1] : indices[0];
-                scroll(false, get_item_position(target) - (get_item_position(target) > (t_size)m_scroll_position ? (si.nPage > 1 ? si.nPage - 1 : 0) - m_item_height : 0));
+                target = get_item_position(indices[0]) > m_scroll_position ? indices[indices_count - 1] : indices[0];
+                scroll(false, get_item_position(target) - (get_item_position(target) > m_scroll_position ? (si.nPage > 1 ? si.nPage - 1 : 0) - m_item_height : 0));
             }
         }
 
@@ -330,8 +330,8 @@ namespace uih {
                 }
             }
 
-            SetWindowLongPtr(m_wnd_inline_edit, GWL_USERDATA, reinterpret_cast<LPARAM>(this));
-            m_proc_inline_edit = reinterpret_cast<WNDPROC>(SetWindowLongPtr(m_wnd_inline_edit, GWL_WNDPROC, reinterpret_cast<LPARAM>(g_on_inline_edit_message)));
+            SetWindowLongPtr(m_wnd_inline_edit, GWLP_USERDATA, reinterpret_cast<LPARAM>(this));
+            m_proc_inline_edit = reinterpret_cast<WNDPROC>(SetWindowLongPtr(m_wnd_inline_edit, GWLP_WNDPROC, reinterpret_cast<LPARAM>(g_on_inline_edit_message)));
 
             SetWindowPos(m_wnd_inline_edit, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -303,7 +303,7 @@ namespace uih {
             //t_size header_height = get_header_height();
             RECT rc_client;
             get_items_rect(&rc_client);
-            t_size groups = get_item_display_group_count(index);
+            const auto groups = gsl::narrow<int>(get_item_display_group_count(index));
             RECT rc_invalidate = {
                 0,
                 get_item_position(index) - m_scroll_position + rc_client.top - groups*m_group_height,
@@ -339,15 +339,15 @@ namespace uih {
         {
             RECT rc_client;
             get_items_rect(&rc_client);
-            t_size groups = get_item_display_group_count(index);
-            t_size item_y = get_item_position(index);
-            t_size items_cy = count * m_item_height, group_area_cy = get_group_info_area_height();
+            const auto group_item_count = gsl::narrow<int>(get_item_display_group_count(index));
+            const auto item_y = get_item_position(index);
+            int items_cy = gsl::narrow<int>(count) * m_item_height, group_area_cy = get_group_info_area_height();
             if (get_show_group_info_area() && items_cy < group_area_cy)
                 items_cy = group_area_cy;
 
             RECT rc_invalidate = {
                 0,
-                item_y - m_scroll_position + rc_client.top - groups * m_item_height,
+                item_y - m_scroll_position + rc_client.top - group_item_count * m_item_height,
                 RECT_CX(rc_client),
                 item_y + group_area_cy - m_scroll_position + rc_client.top
             };

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -384,7 +384,7 @@ namespace uih {
                 POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
                 if (!m_selecting)
                 {
-                    if (m_show_tooltips && ( pt.y >=0 && (t_size)pt.y > get_items_top()))
+                    if (m_show_tooltips && ( pt.y >=0 && pt.y > get_items_top()))
                     {
                         t_hit_test_result hit_result;
                         hit_test_ex(pt, hit_result);

--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -2,24 +2,24 @@
 
 namespace uih {
 
-    const t_size _level_spacing_size = 3;
+    const int _level_spacing_size = 3;
 
-    t_size ListView::get_item_indentation()
+    int ListView::get_item_indentation()
     {
         RECT rc; get_items_rect(&rc);
-        t_size ret = rc.left;
+        int ret = rc.left;
         if (m_group_count)
             ret += get_default_indentation_step()*m_group_count;
         return ret;
     }
-    t_size ListView::get_default_indentation_step()
+    int ListView::get_default_indentation_step()
     {
-        t_size ret = 0;
+        int ret = 0;
         if (m_group_level_indentation_enabled)
         {
             HDC dc = GetDC(get_wnd());
             HFONT font_old = SelectFont(dc, m_font);
-            const t_size cx_space = uih::get_text_width(dc, " ", 1);
+            const int cx_space = uih::get_text_width(dc, " ", 1);
             SelectFont(dc, font_old);
             ReleaseDC(get_wnd(), dc);
             ret = cx_space*_level_spacing_size;
@@ -27,7 +27,7 @@ namespace uih {
         return ret;
     }
 
-    void ListView::render_items(HDC dc, const RECT & rc_update, t_size cx)
+    void ListView::render_items(HDC dc, const RECT & rc_update, int cx)
     {
         ColourData p_data;
         render_get_colour_data(p_data);
@@ -49,9 +49,9 @@ namespace uih {
             return;
 
         t_size i, count = m_items.get_count();
-        const t_size cx_space = uih::get_text_width(dc, " ", 1);
-        const t_size item_preindentation = cx_space*level_spacing_size*m_group_count + rc_items.left;
-        const t_size item_indentation = item_preindentation + get_group_info_area_total_width();
+        const int cx_space = uih::get_text_width(dc, " ", 1);
+        const int item_preindentation = cx_space*level_spacing_size*m_group_count + rc_items.left;
+        const int item_indentation = item_preindentation + get_group_info_area_total_width();
         cx = get_columns_display_width() + item_indentation;
 
         bool b_show_group_info_area = get_show_group_info_area();
@@ -73,8 +73,8 @@ namespace uih {
                 if (!i || m_items[i]->m_groups[j] != m_items[i - 1]->m_groups[j])
                 {
                     t_group_ptr p_group = m_items[i]->m_groups[j];
-                    t_size y = get_item_position(i) - m_scroll_position - m_group_height*(countj - j) + rc_items.top;
-                    t_size x = -m_horizontal_scroll_position + rc_items.left;
+                    int y = get_item_position(i) - m_scroll_position - m_group_height*(countj - j) + rc_items.top;
+                    int x = -m_horizontal_scroll_position + rc_items.left;
                     //y += counter*m_item_height;
                     RECT rc = {x, y, x + cx, y + m_group_height};
 
@@ -93,7 +93,7 @@ namespace uih {
 
             if (b_show_group_info_area && (i == i_start || i == item_group_start))
             {
-                t_size height = max(m_item_height*item_group_count, get_group_info_area_height());
+                int height = (std::max)(m_item_height*gsl::narrow<int>(item_group_count), get_group_info_area_height());
                 int gx = 0 - m_horizontal_scroll_position + item_preindentation;
                 int gy = get_item_position(item_group_start) - m_scroll_position + rc_items.top;
                 int gcx = get_group_info_area_width();
@@ -221,7 +221,7 @@ namespace uih {
             return false;
         return true;
     }
-    void ListView::render_group_default(const ColourData & p_data, HDC dc, const char * text, t_size indentation, t_size level, const RECT & rc)
+    void ListView::render_group_default(const ColourData & p_data, HDC dc, const char * text, int indentation, t_size level, const RECT & rc)
     {
         COLORREF cr = p_data.m_group_text;
 
@@ -230,7 +230,7 @@ namespace uih {
         render_group_background_default(p_data, dc, &rc);
         uih::text_out_colours_tab(dc, text, strlen(text), 2 + indentation*level, 2, &rc, false, cr, false, false, true, uih::ALIGN_LEFT, nullptr, true, true, &text_width);
 
-        t_size cx = text_width;
+        int cx = text_width;
 
         RECT rc_line = {cx + 7, rc.top + RECT_CY(rc) / 2, rc.right - 4, rc.top + RECT_CY(rc) / 2 + 1};
 
@@ -239,7 +239,7 @@ namespace uih {
             render_group_line_default(p_data, dc, &rc_line);
         }
     }
-    void ListView::render_item_default(const ColourData & p_data, HDC dc, t_size index, t_size indentation, bool b_selected, bool b_window_focused, bool b_highlight, bool b_focused, const RECT * rc)
+    void ListView::render_item_default(const ColourData & p_data, HDC dc, t_size index, int indentation, bool b_selected, bool b_window_focused, bool b_highlight, bool b_focused, const RECT * rc)
     {
         t_item_ptr item = m_items[index];
         int theme_state = NULL;
@@ -291,13 +291,13 @@ namespace uih {
         FillRect(dc, rc, gdi_object_t<HBRUSH>::ptr_t(CreateSolidBrush(p_data.m_background)));
     }
 
-    void ListView::render_group(HDC dc, t_size index, t_size group, const char * text, t_size indentation, t_size level, const RECT & rc)
+    void ListView::render_group(HDC dc, t_size index, t_size group, const char * text, int indentation, t_size level, const RECT & rc)
     {
         ColourData p_data;
         render_get_colour_data(p_data);
         render_group_default(p_data, dc, text, indentation, level, rc);
     }
-    void ListView::render_item(HDC dc, t_size index, t_size indentation, bool b_selected, bool b_window_focused, bool b_highlight, bool b_focused, const RECT * rc)
+    void ListView::render_item(HDC dc, t_size index, int indentation, bool b_selected, bool b_window_focused, bool b_highlight, bool b_focused, const RECT * rc)
     {
         ColourData p_data;
         render_get_colour_data(p_data);
@@ -310,9 +310,9 @@ namespace uih {
         render_background_default(p_data, dc, rc);
     }
 
-    t_size ListView::get_text_width(const char * text, t_size length)
+    int ListView::get_text_width(const char * text, t_size length)
     {
-        t_size ret = 0;
+        int ret = 0;
         HDC hdc = GetDC(get_wnd());
         if (hdc)
         {
@@ -332,10 +332,10 @@ namespace uih {
 
         pfc::string8 text = get_item_text(index, column);
         HFONT fnt_old = SelectFont(hdc, m_font);
-        t_size width = uih::get_text_width_colour(hdc, text, text.length());
+        int width = uih::get_text_width_colour(hdc, text, text.length());
         SelectFont(hdc, fnt_old);
         ReleaseDC(get_wnd(), hdc);
-        unsigned col_width = m_columns[column].m_display_size;
+        const auto col_width = m_columns[column].m_display_size;
         //if (column == 0) width += get_total_indentation();
 
         return (width + 7 > col_width);

--- a/list_view/list_view_search.cpp
+++ b/list_view/list_view_search.cpp
@@ -15,8 +15,8 @@ namespace uih {
 
             m_search_label = label;
 
-            SetWindowLongPtr(m_search_editbox, GWL_USERDATA, (LPARAM)(this));
-            m_proc_search_edit = (WNDPROC)SetWindowLongPtr(m_search_editbox, GWL_WNDPROC, (LPARAM)(g_on_search_edit_message));
+            SetWindowLongPtr(m_search_editbox, GWLP_USERDATA, (LPARAM)(this));
+            m_proc_search_edit = (WNDPROC)SetWindowLongPtr(m_search_editbox, GWLP_WNDPROC, (LPARAM)(g_on_search_edit_message));
             //SetWindowPos(m_wnd_inline_edit,HWND_TOP,0,0,0,0,SWP_NOMOVE|SWP_NOSIZE);
             SendMessage(m_search_editbox, WM_SETFONT, (WPARAM)m_font.get(), MAKELONG(TRUE, 0));
             SetWindowTheme(m_search_editbox, L"SearchBoxEdit", nullptr);
@@ -108,7 +108,7 @@ namespace uih {
         ListView * p_this;
         LRESULT rv;
 
-        p_this = reinterpret_cast<ListView*>(GetWindowLongPtr(wnd, GWL_USERDATA));
+        p_this = reinterpret_cast<ListView*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
 
         rv = p_this ? p_this->on_search_edit_message(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);;
 

--- a/stdafx.h
+++ b/stdafx.h
@@ -13,6 +13,8 @@
 
 #include <ppl.h>
 
+#include <gsl/gsl>
+
 // Included before windows.h, because pfc.h includes winsock2.h
 #include "../pfc/pfc.h"
 


### PR DESCRIPTION
Particularly around mixed signed and unsigned comparisons. The ListView class now uses signed ints for dimensions and co-ordindates.

This also introduces a dependency on Microsoft GSL for its safe narrowing cast function.