### PR TITLE
Move character-based keyboard shortcut handling to WM_KEYDOWN

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -469,7 +469,7 @@ public:
     virtual void notify_on_create(){}; // populate list here
     virtual void notify_on_destroy(){};
 
-    virtual bool notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp, bool& b_processed) { return false; };
+    virtual bool notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp) { return false; };
 
     virtual bool notify_on_contextmenu_header(const POINT& pt, const HDHITTESTINFO& ht) { return false; };
 
@@ -717,7 +717,7 @@ private:
 
     void process_navigation_keydown(WPARAM wp, bool alt_down, bool repeat);
     bool on_wm_notify_header(LPNMHDR lpnm, LRESULT& ret);
-    bool on_wm_keydown(WPARAM wp, LPARAM lp, LRESULT& ret);
+    bool on_wm_keydown(WPARAM wp, LPARAM lp);
 
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 

--- a/list_view/list_view_keyboard.cpp
+++ b/list_view/list_view_keyboard.cpp
@@ -2,15 +2,16 @@
 
 namespace uih {
 
-bool ListView::on_wm_keydown(WPARAM wp, LPARAM lp, LRESULT& ret)
+bool ListView::on_wm_keydown(WPARAM wp, LPARAM lp)
 {
     SendMessage(get_wnd(), WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), NULL);
 
-    bool unused{};
-    if (notify_on_keyboard_keydown_filter(WM_KEYDOWN, wp, lp, unused))
+    if (notify_on_keyboard_keydown_filter(WM_KEYDOWN, wp, lp))
         return true;
 
-    ret = 0;
+    const auto is_alt_down = (HIWORD(lp) & KF_ALTDOWN) != 0;
+    const auto is_ctrl_down = (GetKeyState(VK_CONTROL) & KF_UP) != 0;
+    const auto process_ctrl_char_shortcuts = is_ctrl_down && !is_alt_down;
 
     switch (wp) {
     case VK_TAB:
@@ -60,8 +61,26 @@ bool ListView::on_wm_keydown(WPARAM wp, LPARAM lp, LRESULT& ret)
         return notify_on_keyboard_keydown_remove();
     case VK_F3:
         return notify_on_keyboard_keydown_search();
+    case 'A':
+        if (process_ctrl_char_shortcuts && !m_single_selection) {
+            set_selection_state(pfc::bit_array_true(), pfc::bit_array_true());
+            return true;
+        }
+        return false;
+    case 'C':
+        return process_ctrl_char_shortcuts && notify_on_keyboard_keydown_copy();
+    case 'F':
+        return process_ctrl_char_shortcuts && notify_on_keyboard_keydown_search();
+    case 'V':
+        return process_ctrl_char_shortcuts && notify_on_keyboard_keydown_paste();
+    case 'X':
+        return process_ctrl_char_shortcuts && notify_on_keyboard_keydown_cut();
+    case 'Y':
+        return process_ctrl_char_shortcuts && notify_on_keyboard_keydown_redo();
+    case 'Z':
+        return process_ctrl_char_shortcuts && notify_on_keyboard_keydown_undo();
+    default:
+        return false;
     }
-
-    return false;
 }
 } // namespace uih

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -596,54 +596,16 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         }
         break;
     case WM_KEYDOWN: {
-        // console::formatter() << "WM_KEYDOWN: " << (t_size)wp << " " << (t_size)lp;
-        LRESULT ret = 0;
-        if ((m_prevent_wm_char_processing = on_wm_keydown(wp, lp, ret)))
-            return ret;
+        if ((m_prevent_wm_char_processing = on_wm_keydown(wp, lp)))
+            return 0;
     } break;
     case WM_CHAR:
-        // console::formatter() << "WM_CHAR: " << (t_size)wp << " " << (t_size)lp;
-        if (!m_prevent_wm_char_processing) {
-            // if (!(HIWORD(lp) & KF_REPEAT))
-            {
-                if ((GetKeyState(VK_CONTROL) & KF_UP)) {
-                    if (wp == 1) // Ctrl-A
-                    {
-                        if (!m_single_selection)
-                            set_selection_state(pfc::bit_array_true(), pfc::bit_array_true());
-                        return 0;
-                    } else if (wp == 26) // Ctrl-Z
-                    {
-                        if (notify_on_keyboard_keydown_undo())
-                            return 0;
-                    } else if (wp == 25) // Ctrl-Y
-                    {
-                        if (notify_on_keyboard_keydown_redo())
-                            return 0;
-                    } else if (wp == 24) // Ctrl-X
-                    {
-                        if (notify_on_keyboard_keydown_cut())
-                            return 0;
-                    } else if (wp == 3) // Ctrl-C
-                    {
-                        if (notify_on_keyboard_keydown_copy())
-                            return 0;
-                    } else if (wp == 6) // Ctrl-F
-                    {
-                        if (notify_on_keyboard_keydown_search())
-                            return 0;
-                    } else if (wp == 22) // Ctrl-V
-                    {
-                        if (notify_on_keyboard_keydown_paste())
-                            return 0;
-                    }
-                }
-            }
+        // Values below 32, and 127, are special values (e.g. Ctrl-A and Ctrl-Backspace)
+        if (!m_prevent_wm_char_processing && wp >= 32u && wp != 127u)
             on_search_string_change(wp);
-        }
         break;
     case WM_SYSKEYDOWN: {
-        if (notify_on_keyboard_keydown_filter(WM_SYSKEYDOWN, wp, lp, m_prevent_wm_char_processing))
+        if ((m_prevent_wm_char_processing = notify_on_keyboard_keydown_filter(WM_SYSKEYDOWN, wp, lp)))
             return 0;
     } break;
     case WM_VSCROLL:


### PR DESCRIPTION
This is to prevent double-firing if the host processes the same keyboard shortcuts and uses a modal message loop in the process.