### PR TITLE
Avoid unnecessary list view window updates

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -843,6 +843,7 @@ private:
     bool m_sort_direction{false};
     EdgeStyle m_edge_style{edge_grey};
     bool m_sizing{false};
+    bool m_suppress_wm_size_window_updating{false};
 
     bool m_single_selection{false};
     bool m_alternate_selection{false};

--- a/list_view/list_view_items.cpp
+++ b/list_view/list_view_items.cpp
@@ -20,7 +20,7 @@ void ListView::insert_items(t_size index_start, t_size count, const InsertItem* 
     __insert_items_v3(index_start, count, items);
     __calculate_item_positions(index_start);
     // profiler(pvt_render);
-    update_scroll_info();
+    update_scroll_info(b_update_display);
     if (b_update_display)
         RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
 }
@@ -28,10 +28,11 @@ void ListView::replace_items(t_size index_start, t_size count, const InsertItem*
 {
     __replace_items_v2(index_start, count, items);
     __calculate_item_positions(index_start);
-    update_scroll_info();
+    update_scroll_info(b_update_display);
     if (b_update_display)
         RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
 }
+
 void ListView::remove_items(const pfc::bit_array& p_mask, bool b_update_display)
 {
     if (m_timer_inline_edit)
@@ -42,7 +43,7 @@ void ListView::remove_items(const pfc::bit_array& p_mask, bool b_update_display)
             __remove_item(i - 1);
     }
     __calculate_item_positions();
-    update_scroll_info();
+    update_scroll_info(b_update_display);
     if (b_update_display)
         RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
 }

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -17,7 +17,7 @@ void ListView::refresh_item_positions(bool b_update_display)
         : 0.0;
 
     __calculate_item_positions();
-    update_scroll_info();
+    update_scroll_info(b_update_display);
 
     // Restore the scroll position
     const auto new_next_item_top = get_item_position(next_item_index);

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -77,7 +77,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         }
         return 0;*/
     case WM_SIZE:
-        on_size(LOWORD(lp), HIWORD(lp));
+        on_size(LOWORD(lp), HIWORD(lp), !m_suppress_wm_size_window_updating);
         break;
     /*case WM_STYLECHANGING:
         {

--- a/list_view/list_view_scroll.cpp
+++ b/list_view/list_view_scroll.cpp
@@ -180,13 +180,17 @@ void ListView::update_scroll_info(bool b_update, bool b_vertical, bool b_horizon
 {
     // god this is a bit complicated when showing h scrollbar causes need for v scrollbar (and vv)
 
-    // bool b_scroll_shown = (GetWindowLongPtr(get_wnd(), GWL_STYLE) & WS_VSCROLL) != 0;
+    m_suppress_wm_size_window_updating = true;
+
     if (b_vertical) {
         _update_scroll_info_vertical();
     }
     if (b_horizontal) {
         _update_scroll_info_horizontal();
     }
+
+    m_suppress_wm_size_window_updating = false;
+
     if (b_update)
         UpdateWindow(get_wnd());
 }


### PR DESCRIPTION
This avoids unneeded window updates in the list view control, in particular when adding and removing items. This helps avoid flickering in some circumstances.