### PR TITLE
Correct centring of list view items when ensuring an item is visible

### DIFF
--- a/list_view/list_view_scroll.cpp
+++ b/list_view/list_view_scroll.cpp
@@ -27,7 +27,7 @@ void ListView::ensure_visible(t_size index, EnsureVisibleMode mode)
         case ItemVisibility::FullyVisible:
             break;
         default:
-            scroll(item_start_position - (item_area_height + item_height) / 2);
+            scroll(item_start_position - (item_area_height - item_height) / 2);
         }
         break;
     case EnsureVisibleMode::PreferMinimalScrolling:


### PR DESCRIPTION
It was placing the item slightly below the middle of the viewable area due to an incorrect calculation.