### PR TITLE
Fix inability to click between list view items

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -395,7 +395,13 @@ public:
         return position;
     }
 
-    int get_item_position_bottom(t_size index) const { return get_item_position(index) + get_item_height(index); }
+    int get_item_position_bottom(t_size index) const
+    {
+        if (index >= m_items.get_count())
+            return 0;
+
+        return get_item_position(index) + get_item_height(index);
+    }
 
     int get_group_minimum_inner_height() { return get_show_group_info_area() ? get_group_info_area_total_height() : 0; }
 

--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -304,14 +304,11 @@ public:
     /** Current height*/
     unsigned get_header_height() const;
     [[nodiscard]] RECT get_items_rect() const;
-    [[deprecated]] void get_items_rect(LPRECT rc) const { *rc = get_items_rect(); };
     int get_item_area_height() const;
 
     int get_items_top() const
     {
-        RECT rc;
-        get_items_rect(&rc);
-        return rc.top;
+        return get_items_rect().top;
     }
 
     void get_search_box_rect(LPRECT rc) const;

--- a/list_view/list_view_columns.cpp
+++ b/list_view/list_view_columns.cpp
@@ -72,8 +72,7 @@ void ListView::set_column_widths(const pfc::list_base_const_t<int>& widths)
 void ListView::get_column_sizes(pfc::list_t<Column>& p_out)
 {
     // console::formatter() << "get_column_sizes";
-    RECT rc;
-    get_items_rect(&rc);
+    const auto rc = get_items_rect();
     int display_width = RECT_CX(rc), width = get_columns_width(), total_weight = 0, indent = get_total_indentation();
     if (display_width > indent)
         display_width -= indent;

--- a/list_view/list_view_inline_edit.cpp
+++ b/list_view/list_view_inline_edit.cpp
@@ -224,9 +224,9 @@ void ListView::create_inline_edit(const pfc::list_base_const_t<t_size>& indices,
         }
     }
 
-    RECT rc_playlist, rc_items;
+    RECT rc_playlist;
     GetClientRect(get_wnd(), &rc_playlist);
-    get_items_rect(&rc_items);
+    const auto rc_items = get_items_rect();
 
     int font_height = uih::get_font_height(m_font);
     int header_height = rc_items.top;

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -4,26 +4,27 @@ namespace uih {
 
 void ListView::refresh_item_positions(bool b_update_display)
 {
-    // Work out where the scroll position is proportionally between the first fully viewable item
-    // and the item before it
+    // Work out where the scroll position is proportionally in the item at the
+    // scroll position, or between the previous and next items if the scroll
+    // position is between items
     const auto previous_item_index = get_item_at_or_before(m_scroll_position);
     const auto next_item_index = get_item_at_or_after(m_scroll_position);
-    const auto next_item_top = get_item_position(next_item_index);
-    const auto previous_item_bottom = get_item_position(previous_item_index);
-    // If next_item_top == previous_item_bottom == 0, there are probably no items
-    const auto proportional_position = next_item_top != previous_item_bottom
-        ? static_cast<double>(m_scroll_position - previous_item_bottom)
-            / static_cast<double>(next_item_top - previous_item_bottom)
+    const auto next_item_bottom = get_item_position_bottom(next_item_index);
+    const auto previous_item_top = get_item_position(previous_item_index);
+    // If next_item_bottom == previous_item_bottom == 0, there are probably no items
+    const auto proportional_position = next_item_bottom != previous_item_top
+        ? static_cast<double>(m_scroll_position - previous_item_top)
+            / static_cast<double>(next_item_bottom - previous_item_top)
         : 0.0;
 
     __calculate_item_positions();
     update_scroll_info(b_update_display);
 
     // Restore the scroll position
-    const auto new_next_item_top = get_item_position(next_item_index);
-    const auto new_previous_item_bottom = get_item_position(previous_item_index);
-    const auto new_position = proportional_position * static_cast<double>(new_next_item_top - new_previous_item_bottom)
-        + new_previous_item_bottom;
+    const auto new_next_item_bottom = get_item_position_bottom(next_item_index);
+    const auto new_previous_item_top = get_item_position(previous_item_index);
+    const auto new_position = proportional_position * static_cast<double>(new_next_item_bottom - new_previous_item_top)
+        + new_previous_item_top;
     const auto new_position_rounded = gsl::narrow<int>(std::lround(new_position));
     scroll(new_position_rounded, false, false);
 

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -190,8 +190,7 @@ RECT ListView::get_items_rect() const
 
 int ListView::get_item_area_height() const
 {
-    RECT rc{};
-    get_items_rect(&rc);
+    const auto rc = get_items_rect();
     return RECT_CY(rc);
 }
 
@@ -323,8 +322,7 @@ void ListView::on_focus_change(t_size index_prev, t_size index_new, bool b_updat
 }
 void ListView::invalidate_all(bool b_update, bool b_children)
 {
-    RECT rc;
-    get_items_rect(&rc);
+    const auto rc = get_items_rect();
     RedrawWindow(get_wnd(), b_children || true ? nullptr : &rc, nullptr,
         RDW_INVALIDATE | (b_update ? RDW_UPDATENOW : 0) | (b_children ? RDW_ALLCHILDREN : 0));
 }
@@ -366,8 +364,7 @@ void ListView::invalidate_items(t_size index, t_size count, bool b_update_displa
 #else
     if (count) {
         // t_size header_height = get_header_height();
-        RECT rc_client;
-        get_items_rect(&rc_client);
+        const auto rc_client = get_items_rect();
         const auto groups = gsl::narrow<int>(get_item_display_group_count(index));
         RECT rc_invalidate = {0, get_item_position(index) - m_scroll_position + rc_client.top - groups * m_group_height,
             RECT_CX(rc_client),
@@ -399,8 +396,7 @@ void ListView::invalidate_item_group_info_area(t_size index, bool b_update_displ
     t_size count = 0;
     get_item_group(index, m_group_count ? m_group_count - 1 : 0, index, count);
     {
-        RECT rc_client;
-        get_items_rect(&rc_client);
+        const auto rc_client = get_items_rect();
         const auto group_item_count = gsl::narrow<int>(get_item_display_group_count(index));
         const auto item_y = get_item_position(index);
         int items_cy = gsl::narrow<int>(count) * m_item_height, group_area_cy = get_group_info_area_height();

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -130,9 +130,8 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         return FALSE;
     case WM_PAINT: {
         // console::formatter() << "WM_PAINT";
-        RECT rc_client;
+        const auto rc_client = get_items_rect();
         // GetClientRect(wnd, &rc_client);
-        get_items_rect(&rc_client);
         // GetUpdateRect(wnd, &rc2, FALSE);
 
         PAINTSTRUCT ps;
@@ -743,8 +742,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                         px.x = 0;
                         px.y = 0;
                     } else {
-                        RECT rc;
-                        get_items_rect(&rc);
+                        const auto rc = get_items_rect();
                         px.x = 0;
                         px.y = (get_item_position(focus) - m_scroll_position) + m_item_height / 2 + rc.top;
                     }

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -186,20 +186,21 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         exit_inline_edit();
         SetFocus(wnd);
         POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
-        t_hit_test_result hit_result;
+        HitTestResult hit_result;
         hit_test_ex(pt, hit_result);
         m_lbutton_down_hittest = hit_result;
         bool b_shift_down = (wp & MK_SHIFT) != 0;
         m_lbutton_down_ctrl = (wp & MK_CONTROL) != 0 && !m_single_selection; // Cheat.
 
-        if (hit_result.result == hit_test_on || hit_result.result == hit_test_obscured_below
-            || hit_result.result == hit_test_obscured_above) {
+        if (hit_result.category == HitTestCategory::OnUnobscuredItem
+            || hit_result.category == HitTestCategory::OnItemObscuredBelow
+            || hit_result.category == HitTestCategory::OnItemObscuredAbove) {
             if (!m_inline_edit_prevent)
                 m_inline_edit_prevent
                     = !((get_item_selected(hit_result.index) && !m_wnd_inline_edit && (get_selection_count(2) == 1)));
-            if (hit_result.result == hit_test_obscured_below)
+            if (hit_result.category == HitTestCategory::OnItemObscuredBelow)
                 ensure_visible(hit_result.index);
-            if (hit_result.result == hit_test_obscured_above)
+            if (hit_result.category == HitTestCategory::OnItemObscuredAbove)
                 ensure_visible(hit_result.index);
 
             m_dragging_initial_point = pt;
@@ -238,7 +239,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 }
             }
             SetCapture(wnd);
-        } else if (hit_result.result == hit_test_on_group) {
+        } else if (hit_result.category == HitTestCategory::OnGroupHeader) {
             if (!m_single_selection) {
                 t_size index = 0, count = 0;
                 if (!m_lbutton_down_ctrl) {
@@ -284,15 +285,16 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             destroy_timer_scroll_down();
             destroy_timer_scroll_up();
         } else if (m_lbutton_down_ctrl) {
-            const t_hit_test_result& hit_result = m_lbutton_down_hittest;
+            const HitTestResult& hit_result = m_lbutton_down_hittest;
             if (wp & MK_CONTROL) {
-                if (hit_result.result == hit_test_on || hit_result.result == hit_test_obscured_below
-                    || hit_result.result == hit_test_obscured_above) {
+                if (hit_result.category == HitTestCategory::OnUnobscuredItem
+                    || hit_result.category == HitTestCategory::OnItemObscuredBelow
+                    || hit_result.category == HitTestCategory::OnItemObscuredAbove) {
                     if (m_selecting_start < m_items.get_count()) {
                         set_item_selected(m_selecting_start, !get_item_selected(m_selecting_start));
                         set_focus_item(m_selecting_start);
                     }
-                } else if (hit_result.result == hit_test_on_group) {
+                } else if (hit_result.category == HitTestCategory::OnGroupHeader) {
                     if (hit_result.index < m_items.get_count() && hit_result.group_level < m_group_count) {
                         t_size index = 0, count = 0;
                         get_item_group(hit_result.index, hit_result.group_level, index, count);
@@ -325,14 +327,16 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         SetFocus(wnd);
 
         POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
-        t_hit_test_result hit_result;
+        HitTestResult hit_result;
         hit_test_ex(pt, hit_result);
-        if (hit_result.result == hit_test_on || hit_result.result == hit_test_obscured_below
-            || hit_result.result == hit_test_obscured_above) {
+        if (hit_result.category == HitTestCategory::OnUnobscuredItem
+            || hit_result.category == HitTestCategory::OnItemObscuredBelow
+            || hit_result.category == HitTestCategory::OnItemObscuredAbove) {
             m_dragging_rmb = true;
             m_dragging_rmb_initial_point = pt;
 
-            if (hit_result.result == hit_test_obscured_below || hit_result.result == hit_test_obscured_above)
+            if (hit_result.category == HitTestCategory::OnItemObscuredBelow
+                || hit_result.category == HitTestCategory::OnItemObscuredAbove)
                 ensure_visible(hit_result.index);
 
             if (!get_item_selected(hit_result.index)) {
@@ -342,7 +346,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     set_item_selected_single(hit_result.index, true, notification_source_rmb);
             } else if (get_focus_item() != hit_result.index)
                 set_focus_item(hit_result.index);
-        } else if (hit_result.result == hit_test_on_group) {
+        } else if (hit_result.category == HitTestCategory::OnGroupHeader) {
             t_size index = 0, count = 0;
             get_item_group(hit_result.index, hit_result.group_level, index, count);
             set_selection_state(pfc::bit_array_true(), pfc::bit_array_range(index, count));
@@ -358,11 +362,12 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
         if (!m_selecting) {
             if (m_show_tooltips && (pt.y >= 0 && pt.y > get_items_top())) {
-                t_hit_test_result hit_result;
+                HitTestResult hit_result;
                 hit_test_ex(pt, hit_result);
 
-                if ((hit_result.result == hit_test_on || hit_result.result == hit_test_obscured_below
-                        || hit_result.result == hit_test_obscured_above)
+                if ((hit_result.category == HitTestCategory::OnUnobscuredItem
+                        || hit_result.category == HitTestCategory::OnItemObscuredBelow
+                        || hit_result.category == HitTestCategory::OnItemObscuredAbove)
                     && hit_result.column != -1) {
                     if (m_tooltip_last_index != hit_result.index || m_tooltip_last_column != hit_result.column) {
                         t_size cx = 0;
@@ -441,35 +446,39 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (m_selecting && !m_single_selection) {
             // t_size index;
             if (!m_selecting_move) {
-                t_hit_test_result hit_result;
+                HitTestResult hit_result;
                 hit_test_ex(pt, hit_result);
                 {
-                    if (hit_result.result == hit_test_above || hit_result.result == hit_test_below
-                        || hit_result.result == hit_test_on
+                    if (hit_result.category == HitTestCategory::AboveViewport
+                        || hit_result.category == HitTestCategory::BelowViewport
+                        || hit_result.category == HitTestCategory::OnUnobscuredItem
                         //|| hit_result.result == hit_test_obscured_below || hit_result.result ==
-                        //hit_test_obscured_above
-                        || hit_result.result == hit_test_right_of_item || hit_result.result == hit_test_left_of_item
-                        || hit_result.result == hit_test_right_of_group || hit_result.result == hit_test_left_of_group
-                        || hit_result.result == hit_test_below_items || hit_result.result == hit_test_on_group) {
-                        if (hit_result.result == hit_test_below) {
+                        // hit_test_obscured_above
+                        || hit_result.category == HitTestCategory::RightOfItem
+                        || hit_result.category == HitTestCategory::LeftOfItem
+                        || hit_result.category == HitTestCategory::RightOfGroupHeader
+                        || hit_result.category == HitTestCategory::LeftOfGroupHeader
+                        || hit_result.category == HitTestCategory::NotOnItem
+                        || hit_result.category == HitTestCategory::OnGroupHeader) {
+                        if (hit_result.category == HitTestCategory::BelowViewport) {
                             create_timer_scroll_down();
                         } else
                             destroy_timer_scroll_down();
 
-                        if (hit_result.result == hit_test_above) {
+                        if (hit_result.category == HitTestCategory::AboveViewport) {
                             create_timer_scroll_up();
                         } else
                             destroy_timer_scroll_up();
 
-                        if (hit_result.result == hit_test_obscured_below
-                            || hit_result.result == hit_test_obscured_above)
+                        if (hit_result.category == HitTestCategory::OnItemObscuredBelow
+                            || hit_result.category == HitTestCategory::OnItemObscuredAbove)
                             ensure_visible(hit_result.index);
 
-                        if (hit_result.result == hit_test_on_group) {
+                        if (hit_result.category == HitTestCategory::OnGroupHeader) {
                             if (hit_result.index > m_selecting_start)
                                 hit_result.index--;
                         }
-                        if (hit_result.result == hit_test_below_items && hit_result.index < m_selecting_start
+                        if (hit_result.category == HitTestCategory::NotOnItem && hit_result.index < m_selecting_start
                             && hit_result.index + 1 < get_item_count()) // Items removed whilst selecting.. messy
                             hit_result.index++;
 
@@ -486,7 +495,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                         {
                             if (get_focus_item() != hit_result.index) {
                                 if (!is_partially_visible(hit_result.index)) {
-                                    if (hit_result.index > get_last_viewable_item())
+                                    if (gsl::narrow_cast<int>(hit_result.index) > get_last_viewable_item())
                                         scroll(get_item_position_bottom(hit_result.index) - get_item_area_height());
                                     else
                                         scroll(get_item_position(hit_result.index));
@@ -506,17 +515,18 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         return 0;
     case WM_LBUTTONDBLCLK: {
         POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
-        t_hit_test_result hit_result;
+        HitTestResult hit_result;
         hit_test_ex(pt, hit_result);
-        if (hit_result.result == hit_test_on) {
+        if (hit_result.category == HitTestCategory::OnUnobscuredItem) {
             exit_inline_edit();
             m_inline_edit_prevent = true;
             t_size focus = get_focus_item();
             if (focus != pfc_infinite)
                 execute_default_action(focus, hit_result.column, false, (wp & MK_CONTROL) != 0);
             return 0;
-        } else if (hit_result.result == hit_test_nowhere || hit_result.result == hit_test_right_of_item
-            || hit_result.result == hit_test_right_of_group || hit_result.result == hit_test_below_items)
+        } else if (hit_result.category == HitTestCategory::RightOfItem
+            || hit_result.category == HitTestCategory::RightOfGroupHeader
+            || hit_result.category == HitTestCategory::NotOnItem)
             if (notify_on_doubleleftclick_nowhere())
                 return 0;
     } break;
@@ -527,9 +537,9 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_MBUTTONUP: {
         m_inline_edit_prevent = false;
         POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
-        t_hit_test_result hit_result;
+        HitTestResult hit_result;
         hit_test_ex(pt, hit_result);
-        if (notify_on_middleclick(hit_result.result == hit_test_on, hit_result.index))
+        if (notify_on_middleclick(hit_result.category == HitTestCategory::OnUnobscuredItem, hit_result.index))
             return 0;
     } break;
     case WM_MOUSEHWHEEL:
@@ -728,7 +738,8 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 if (from_keyboard) {
                     t_size focus = get_focus_item();
                     unsigned last = get_last_viewable_item();
-                    if (focus >= m_items.get_count() || focus < get_next_item(m_scroll_position) || focus > last) {
+                    if (focus >= m_items.get_count() || focus < get_item_at_or_after(m_scroll_position)
+                        || focus > last) {
                         px.x = 0;
                         px.y = 0;
                     } else {

--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -57,11 +57,11 @@ void ListView::render_items(HDC dc, const RECT& rc_update, int cx)
 
     bool b_show_group_info_area = get_show_group_info_area();
 
-    i = get_previous_item((rc_update.top > rc_items.top ? rc_update.top - rc_items.top : 0) + m_scroll_position, true);
+    i = get_item_at_or_before((rc_update.top > rc_items.top ? rc_update.top - rc_items.top : 0) + m_scroll_position);
     t_size i_start = i;
-    t_size i_end = get_previous_item(
-        (rc_update.bottom > rc_items.top + 1 ? rc_update.bottom - rc_items.top - 1 : 0) + m_scroll_position, true);
-    for (; i <= i_end, i < count; i++) {
+    t_size i_end = get_item_at_or_after(
+        (rc_update.bottom > rc_items.top + 1 ? rc_update.bottom - rc_items.top - 1 : 0) + m_scroll_position);
+    for (; i <= i_end && i < count; i++) {
         HFONT fnt_old = SelectFont(dc, m_group_font.get());
         t_size item_group_start = NULL, item_group_count = NULL;
         get_item_group(i, m_group_count ? m_group_count - 1 : 0, item_group_start, item_group_count);

--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -6,8 +6,7 @@ const int _level_spacing_size = 3;
 
 int ListView::get_item_indentation()
 {
-    RECT rc;
-    get_items_rect(&rc);
+    const auto rc = get_items_rect();
     int ret = rc.left;
     if (m_group_count)
         ret += get_default_indentation_step() * m_group_count;
@@ -43,8 +42,7 @@ void ListView::render_items(HDC dc, const RECT& rc_update, int cx)
     bool b_window_focused = (wnd_focus == get_wnd()) || IsChild(get_wnd(), wnd_focus);
 
     render_background(dc, &rc_update);
-    RECT rc_items;
-    get_items_rect(&rc_items);
+    const auto rc_items = get_items_rect();
 
     if (rc_update.bottom <= rc_update.top || rc_update.bottom < rc_items.top)
         return;

--- a/list_view/list_view_scroll.cpp
+++ b/list_view/list_view_scroll.cpp
@@ -63,8 +63,7 @@ void ListView::scroll(int position, bool b_horizontal, bool update_display)
     destroy_tooltip();
     scroll_position = SetScrollInfo(get_wnd(), scroll_bar_type, &scroll_info, true);
 
-    RECT playlist{};
-    get_items_rect(&playlist);
+    const auto playlist = get_items_rect();
     int dx = 0;
     int dy = 0;
     (b_horizontal ? dx : dy) = original_scroll_position - scroll_position;
@@ -113,8 +112,7 @@ void ListView::scroll_from_scroll_bar(short scroll_bar_command, bool b_horizonta
 
 void ListView::_update_scroll_info_vertical()
 {
-    RECT rc;
-    get_items_rect(&rc);
+    const auto rc = get_items_rect();
 
     t_size old_scroll_position = m_scroll_position;
     SCROLLINFO scroll;
@@ -139,8 +137,7 @@ void ListView::_update_scroll_info_vertical()
 
 void ListView::_update_scroll_info_horizontal()
 {
-    RECT rc;
-    get_items_rect(&rc);
+    auto rc = get_items_rect();
 
     t_size old_scroll_position = m_horizontal_scroll_position;
     t_size cx = get_columns_display_width() + get_total_indentation();
@@ -167,7 +164,7 @@ void ListView::_update_scroll_info_horizontal()
     if (m_horizontal_scroll_position != old_scroll_position /* || b_old_show != b_show*/)
         invalidate_all(false);
     if (b_old_show != b_show) {
-        get_items_rect(&rc);
+        rc = get_items_rect();
         memset(&scroll, 0, sizeof(SCROLLINFO));
         scroll.cbSize = sizeof(SCROLLINFO);
         scroll.fMask = SIF_PAGE;


### PR DESCRIPTION
There was a lot of confusion in the code base around what `ListView::get_previous_item()` and `ListView::get_next_item()` were meant to do.

This replaces those functions with better defined ones and rewrites the hit testing code using cleaner logic.