### PR TITLE
Remove forced list view window updating

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -218,28 +218,25 @@ public:
     void set_show_sort_indicators(bool b_val);
     void set_edge_style(t_size b_val);
 
-    void on_size(bool b_update = true, bool b_update_scroll = true);
-    void on_size(int cx, int cy, bool b_update = true, bool b_update_scroll = true);
+    void on_size(bool b_update_scroll = true);
+    void on_size(int cx, int cy, bool b_update_scroll = true);
 
     void reposition_header();
 
     void get_column_sizes(pfc::list_t<Column>& p_out);
     void update_column_sizes();
 
-    // void insert_item(t_size index, const t_string_list_const_fast & text, const t_string_list_const_fast & p_groups,
-    // t_size size); void insert_items(t_size index_start, const pfc::list_base_const_t<InsertItem> & items, bool
-    // b_update_display = true);
-    void insert_items(t_size index_start, t_size count, const InsertItem* items, bool b_update_display = true);
+    void insert_items(t_size index_start, t_size count, const InsertItem* items);
 
     template <class TItems>
-    void replace_items(t_size index_start, const TItems& items, bool b_update_display = true)
+    void replace_items(t_size index_start, const TItems& items)
     {
-        replace_items(index_start, items.get_size(), items.get_ptr(), b_update_display);
+        replace_items(index_start, items.get_size(), items.get_ptr());
     }
-    void replace_items(t_size index_start, t_size count, const InsertItem* items, bool b_update_display = true);
+    void replace_items(t_size index_start, t_size count, const InsertItem* items);
     void remove_item(t_size index);
-    void remove_items(const pfc::bit_array& p_mask, bool b_update_display = true);
-    void remove_all_items(bool b_update_display = true);
+    void remove_items(const pfc::bit_array& p_mask);
+    void remove_all_items();
 
     enum class HitTestCategory {
         NotOnItem,
@@ -272,7 +269,7 @@ public:
     };
 
     void hit_test_ex(POINT pt_client, HitTestResult& result);
-    void update_scroll_info(bool b_update = true, bool b_vertical = true, bool b_horizontal = true);
+    void update_scroll_info(bool b_vertical = true, bool b_horizontal = true);
     void _update_scroll_info_vertical();
     void _update_scroll_info_horizontal();
     ItemVisibility get_item_visibility(t_size index);
@@ -286,7 +283,7 @@ public:
 
     void ensure_visible(t_size index, EnsureVisibleMode mode = EnsureVisibleMode::PreferCentringItem);
 
-    void scroll(int position, bool b_horizontal = false, bool update_display = true);
+    void scroll(int position, bool b_horizontal = false, bool suppress_scroll_window = false);
     void scroll_from_scroll_bar(short scroll_bar_command, bool b_horizontal = false);
 
     void get_item_group(t_size index, t_size level, t_size& index_start, t_size& count);
@@ -314,18 +311,17 @@ public:
     void get_search_box_rect(LPRECT rc) const;
     unsigned get_search_box_height() const;
 
-    void invalidate_all(bool b_update = true, bool b_children = false);
-    void invalidate_items(t_size index, t_size count, bool b_update_display = true);
+    void invalidate_all(bool b_children = false);
+    void invalidate_items(t_size index, t_size count);
 
-    void invalidate_items(const pfc::bit_array& mask, bool b_update_display = true);
-    void invalidate_item_group_info_area(t_size index, bool b_update_display = true);
+    void invalidate_items(const pfc::bit_array& mask);
+    void invalidate_item_group_info_area(t_size index);
 
-    void update_items(t_size index, t_size count, bool b_update_display = true);
-    void update_all_items(bool b_update_display = true);
+    void update_items(t_size index, t_size count);
+    void update_all_items();
 
     // Current implementation clears sub-items.
-    void reorder_items_partial(
-        size_t base, const size_t* order, size_t count, bool update_focus_item = true, bool update_display = true);
+    void reorder_items_partial(size_t base, const size_t* order, size_t count, bool update_focus_item = true);
 
     enum class VerticalPositionCategory {
         OnItem,
@@ -423,7 +419,7 @@ public:
         return ret;
     }
 
-    void refresh_item_positions(bool b_update_display = true);
+    void refresh_item_positions();
 
     enum notification_source_t {
         notification_source_unknown,
@@ -435,9 +431,9 @@ public:
     // CLIENT FUNCTIONS
     void get_selection_state(pfc::bit_array_var& out);
     void set_selection_state(const pfc::bit_array& p_affected, const pfc::bit_array& p_status, bool b_notify = true,
-        bool b_update_display = true, notification_source_t p_notification_source = notification_source_unknown);
+        notification_source_t p_notification_source = notification_source_unknown);
     t_size get_focus_item();
-    void set_focus_item(t_size index, bool b_notify = true, bool b_update_display = true);
+    void set_focus_item(t_size index, bool b_notify = true);
     bool get_item_selected(t_size index);
 
     bool is_range_selected(t_size index, t_size count)
@@ -565,8 +561,6 @@ public:
     bool disable_redrawing();
     void enable_redrawing();
 
-    void update_window() { UpdateWindow(get_wnd()); }
-
     const char* get_item_text(t_size index, t_size column);
 
     t_size get_item_count() { return m_items.get_count(); }
@@ -613,7 +607,7 @@ protected:
         }
     }
 
-    void on_focus_change(t_size index_prev, t_size index_new, bool b_update_display = true);
+    void on_focus_change(t_size index_prev, t_size index_new);
 
     void set_group_level_indentation_enabled(bool b_val)
     {
@@ -795,7 +789,7 @@ private:
     void create_header();
     void destroy_header();
     void build_header();
-    void update_header(bool b_update = true);
+    void update_header();
 
     void create_tooltip(/*t_size index, t_size column, */ const char* str);
     void destroy_tooltip();
@@ -878,7 +872,6 @@ private:
     bool m_sort_direction{false};
     EdgeStyle m_edge_style{edge_grey};
     bool m_sizing{false};
-    bool m_suppress_wm_size_window_updating{false};
 
     bool m_single_selection{false};
     bool m_alternate_selection{false};

--- a/list_view/list_view_columns.cpp
+++ b/list_view/list_view_columns.cpp
@@ -48,8 +48,7 @@ void ListView::set_columns(const pfc::list_base_const_t<Column>& columns)
     if (m_initialised) {
         build_header();
         _update_scroll_info_horizontal();
-        on_size(false, false);
-        UpdateWindow(get_wnd());
+        on_size(false);
     }
 }
 
@@ -64,9 +63,8 @@ void ListView::set_column_widths(const pfc::list_base_const_t<int>& widths)
     update_header();
     if (m_wnd_header)
         SendMessage(m_wnd_header, WM_SETREDRAW, TRUE, NULL);
-    invalidate_all(false);
+    invalidate_all();
     on_size();
-    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_ALLCHILDREN | RDW_UPDATENOW);
 }
 
 void ListView::get_column_sizes(pfc::list_t<Column>& p_out)

--- a/list_view/list_view_header.cpp
+++ b/list_view/list_view_header.cpp
@@ -308,7 +308,7 @@ unsigned ListView::calculate_header_height()
     return rv;
 }
 
-void ListView::update_header(bool b_update)
+void ListView::update_header()
 {
     if (m_wnd_header) {
         pfc::vartoggle_t<bool> toggle(m_ignore_column_size_change_notification, true);

--- a/list_view/list_view_item_state.cpp
+++ b/list_view/list_view_item_state.cpp
@@ -8,12 +8,11 @@ void ListView::get_selection_state(pfc::bit_array_var& out)
 }
 
 void ListView::set_selection_state(const pfc::bit_array& p_affected, const pfc::bit_array& p_status, bool b_notify,
-    bool b_update_display, notification_source_t p_notification_source)
+    notification_source_t p_notification_source)
 {
     pfc::bit_array_bittable p_changed(get_item_count());
     if (storage_set_selection_state(p_affected, p_status, &p_changed)) {
-        invalidate_items(p_changed, b_update_display);
-        // RedrawWindow(get_wnd(), NULL, NULL, RDW_INVALIDATE|(b_update_display?RDW_UPDATENOW:0));
+        invalidate_items(p_changed);
         if (b_notify)
             notify_on_selection_change(p_changed, p_status, p_notification_source);
     }
@@ -27,12 +26,12 @@ t_size ListView::get_focus_item()
     return ret;
 }
 
-void ListView::set_focus_item(t_size index, bool b_notify, bool b_update_display)
+void ListView::set_focus_item(t_size index, bool b_notify)
 {
     t_size old = storage_get_focus_item();
     if (old != index) {
         storage_set_focus_item(index);
-        on_focus_change(old, index, b_update_display);
+        on_focus_change(old, index);
         if (b_notify)
             notify_on_focus_item_change(index);
     }
@@ -71,9 +70,8 @@ void ListView::set_item_selected(t_size index, bool b_state)
 void ListView::set_item_selected_single(t_size index, bool b_notify, notification_source_t p_notification_source)
 {
     if (index < m_items.get_count()) {
-        set_selection_state(pfc::bit_array_true(), pfc::bit_array_one(index), b_notify, false, p_notification_source);
-        set_focus_item(index, b_notify, false);
-        UpdateWindow(get_wnd());
+        set_selection_state(pfc::bit_array_true(), pfc::bit_array_one(index), b_notify, p_notification_source);
+        set_focus_item(index, b_notify);
         // ensure_visible(index);
     }
 }

--- a/list_view/list_view_items.cpp
+++ b/list_view/list_view_items.cpp
@@ -15,25 +15,24 @@ const char* ListView::get_item_text(t_size index, t_size column)
     return m_items[index]->m_subitems[column];
 }
 
-void ListView::insert_items(t_size index_start, t_size count, const InsertItem* items, bool b_update_display)
+void ListView::insert_items(t_size index_start, t_size count, const InsertItem* items)
 {
     __insert_items_v3(index_start, count, items);
     __calculate_item_positions(index_start);
     // profiler(pvt_render);
-    update_scroll_info(b_update_display);
-    if (b_update_display)
-        RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
+    update_scroll_info();
+    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
 }
-void ListView::replace_items(t_size index_start, t_size count, const InsertItem* items, bool b_update_display)
+
+void ListView::replace_items(t_size index_start, t_size count, const InsertItem* items)
 {
     __replace_items_v2(index_start, count, items);
     __calculate_item_positions(index_start);
-    update_scroll_info(b_update_display);
-    if (b_update_display)
-        RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
+    update_scroll_info();
+    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
 }
 
-void ListView::remove_items(const pfc::bit_array& p_mask, bool b_update_display)
+void ListView::remove_items(const pfc::bit_array& p_mask)
 {
     if (m_timer_inline_edit)
         exit_inline_edit();
@@ -43,21 +42,19 @@ void ListView::remove_items(const pfc::bit_array& p_mask, bool b_update_display)
             __remove_item(i - 1);
     }
     __calculate_item_positions();
-    update_scroll_info(b_update_display);
-    if (b_update_display)
-        RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
+    update_scroll_info();
+    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
 }
 
-void ListView::remove_all_items(bool b_update_display)
+void ListView::remove_all_items()
 {
     if (m_timer_inline_edit)
         exit_inline_edit();
 
     m_items.remove_all();
-	update_scroll_info(b_update_display);
-    
-    if (b_update_display)
-        RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
+    update_scroll_info();
+
+    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
 }
 
 void ListView::__replace_items_v2(t_size index_start, t_size countl, const InsertItem* items)
@@ -375,7 +372,7 @@ void ListView::remove_item(t_size index)
     __remove_item(index);
     __calculate_item_positions();
     update_scroll_info();
-    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
+    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
 }
 void ListView::__remove_item(t_size index)
 {

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -77,7 +77,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         }
         return 0;*/
     case WM_SIZE:
-        on_size(LOWORD(lp), HIWORD(lp), !m_suppress_wm_size_window_updating);
+        on_size(LOWORD(lp), HIWORD(lp));
         break;
     /*case WM_STYLECHANGING:
         {
@@ -213,17 +213,16 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 t_size start = m_alternate_selection ? focus : m_shift_start;
                 pfc::bit_array_range br(min(start, hit_result.index), abs(t_ssize(start - hit_result.index)) + 1);
                 if (m_lbutton_down_ctrl && !m_alternate_selection) {
-                    set_selection_state(br, br, true, false);
+                    set_selection_state(br, br, true);
                 } else {
                     if (m_alternate_selection && !get_item_selected(focus))
-                        set_selection_state(br, pfc::bit_array_not(br), true, false);
+                        set_selection_state(br, pfc::bit_array_not(br), true);
                     else if (m_alternate_selection)
-                        set_selection_state(br, br, true, false);
+                        set_selection_state(br, br, true);
                     else
-                        set_selection_state(pfc::bit_array_true(), br, true, false);
+                        set_selection_state(pfc::bit_array_true(), br, true);
                 }
-                set_focus_item(hit_result.index, true, false);
-                UpdateWindow(get_wnd());
+                set_focus_item(hit_result.index, true);
             } else {
                 m_selecting_move = get_item_selected(hit_result.index);
                 m_selecting_moved = false;
@@ -299,7 +298,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                         get_item_group(hit_result.index, hit_result.group_level, index, count);
                         if (count) {
                             set_selection_state(pfc::bit_array_range(index, count),
-                                pfc::bit_array_range(index, count, !is_range_selected(index, count)), true, false);
+                                pfc::bit_array_range(index, count, !is_range_selected(index, count)), true);
                             set_focus_item(index);
                         }
                     }
@@ -644,13 +643,13 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 notify_on_search_box_contents_change(text);
             } break;
             case EN_KILLFOCUS: {
-                RedrawWindow(HWND(lp), nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_ERASENOW | RDW_UPDATENOW);
+                RedrawWindow(HWND(lp), nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE);
                 HWND wnd_focus = GetFocus();
                 if (!HWND(wnd_focus) || (HWND(wnd_focus) != wnd && !IsChild(wnd, wnd_focus)))
                     notify_on_kill_focus(wnd_focus);
             } break;
             case EN_SETFOCUS:
-                RedrawWindow(HWND(lp), nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_ERASENOW | RDW_UPDATENOW);
+                RedrawWindow(HWND(lp), nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE);
                 break;
             };
             break;

--- a/list_view/list_view_search.cpp
+++ b/list_view/list_view_search.cpp
@@ -189,7 +189,7 @@ void ListView::__search_box_update_hot_status(const POINT& pt)
             SetCapture(m_search_editbox);
         else if (GetCapture() == m_search_editbox)
             ReleaseCapture();
-        RedrawWindow(m_search_editbox, nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ERASENOW);
+        RedrawWindow(m_search_editbox, nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE);
     }
 }
 


### PR DESCRIPTION
This removes nearly all use of `UpdateWindow()` and `RDW_UPDATENOW` in the list view control to minimise flickering (and similar effects).