### PR TITLE
Correct handling of space key in list view

### DIFF
--- a/list_view/list_view_keyboard.cpp
+++ b/list_view/list_view_keyboard.cpp
@@ -38,8 +38,9 @@ bool ListView::on_wm_keydown(WPARAM wp, LPARAM lp)
 
             if (focus != pfc_infinite)
                 set_item_selected(focus, !get_item_selected(focus));
+            return true;
         }
-        return true;
+        return false;
     }
     case VK_RETURN: {
         const bool ctrl_down = 0 != (GetKeyState(VK_CONTROL) & KF_UP);

--- a/list_view/list_view_keyboard.cpp
+++ b/list_view/list_view_keyboard.cpp
@@ -32,8 +32,7 @@ bool ListView::on_wm_keydown(WPARAM wp, LPARAM lp)
         return true;
     }
     case VK_SPACE: {
-        const bool ctrl_down = 0 != (GetKeyState(VK_CONTROL) & KF_UP);
-        if (ctrl_down) {
+        if (is_ctrl_down) {
             const t_size focus = get_focus_item();
 
             if (focus != pfc_infinite)
@@ -43,10 +42,9 @@ bool ListView::on_wm_keydown(WPARAM wp, LPARAM lp)
         return false;
     }
     case VK_RETURN: {
-        const bool ctrl_down = 0 != (GetKeyState(VK_CONTROL) & KF_UP);
         const t_size focus = get_focus_item();
         if (focus != pfc_infinite)
-            execute_default_action(focus, pfc_infinite, true, ctrl_down);
+            execute_default_action(focus, pfc_infinite, true, is_ctrl_down);
         return true;
     }
     case VK_SHIFT:


### PR DESCRIPTION
This fixes a bug where pressing space in the list view (when typing the text of an item) misbehaved and did not jump to items matching the text entered, due to a bug in how the Ctrl+Space keyboard shortcut was handled.