### PR TITLE
Fix display of ellipsis in truncated text containing colour codes

### DIFF
--- a/text_drawing.cpp
+++ b/text_drawing.cpp
@@ -162,18 +162,22 @@ BOOL text_out_colours_ellipsis(HDC dc, const char* src_c, int src_c_len, int x_o
     bool selected, bool show_ellipsis, DWORD default_color, alignment align, unsigned* p_width,
     bool b_set_default_colours, int* p_position)
 {
-    class colour_change_data {
-    public:
-        t_size index, length;
-        COLORREF colour;
+    struct ColouredTextSegment {
+        std::wstring text;
+        COLORREF colour{};
+        int left_offset{};
+        UniscribeTextRenderer renderer{};
+        std::vector<int> character_right_offsets{};
+
+        void analyse(HDC dc)
+        {
+            renderer.analyse(dc, text.data(), text.size(), -1, false);
+            character_right_offsets.resize(text.length());
+            renderer.get_character_logical_extents(character_right_offsets.data(), left_offset);
+        }
     };
 
     pfc::stringcvt::string_wide_from_utf8 wstr(src_c, src_c_len);
-
-    pfc::array_t<wchar_t> src_s;
-    const wchar_t* src = wstr.get_ptr();
-
-    t_size wLen = wstr.length();
 
     if (!base_clip)
         return FALSE;
@@ -184,12 +188,13 @@ BOOL text_out_colours_ellipsis(HDC dc, const char* src_c, int src_c_len, int x_o
             return TRUE;
     }
 
-    pfc::list_t<colour_change_data, pfc::alloc_fast_aggressive> colourChanges;
-
-    bool b_lastColourUsed = true;
-    COLORREF cr_last = NULL;
+    std::vector<ColouredTextSegment> segments;
+    std::optional<COLORREF> cr_last;
 
     {
+        const wchar_t* src = wstr.get_ptr();
+        t_size wLen = wstr.length();
+
         const wchar_t* p_start = src;
         const wchar_t* p_block_start = src;
         const wchar_t* p_current = src;
@@ -202,143 +207,124 @@ BOOL text_out_colours_ellipsis(HDC dc, const char* src_c, int src_c_len, int x_o
                 p_current++;
             }
             if (p_current > p_block_start) {
-                colour_change_data temp;
-                temp.index = src_s.get_size();
-                // p_block_start - src;
-                temp.length = p_current - p_block_start;
-                temp.colour = cr_current;
-                colourChanges.add_item(temp);
-                src_s.append_fromptr(p_block_start, p_current - p_block_start);
-                b_lastColourUsed = true;
-            } else if (size_t(p_current - p_start) >= wLen)
+                ColouredTextSegment segment{
+                    {p_block_start, gsl::narrow<size_t>(p_current - p_block_start)}, cr_current};
+                segments.emplace_back(std::move(segment));
+
+                cr_last.reset();
+            }
+
+            // need another at least char for valid colour code operation
+            if (size_t(p_current + 1 - p_start) >= wLen)
                 break;
-            if (size_t(p_current - p_start) + 1 < wLen) // need another at least char for valid colour code operation
-            {
-                if (p_current[0] == 3) {
-                    COLORREF new_colour;
-                    COLORREF new_colour_selected;
 
-                    bool have_selected = false;
+            if (p_current[0] == 3) {
+                COLORREF new_colour;
+                COLORREF new_colour_selected;
 
-                    if (p_current[1] == 3) {
-                        new_colour = new_colour_selected = default_color;
-                        have_selected = true;
-                        p_current += 2;
-                    } else {
-                        p_current++;
-                        new_colour = mmh::strtoul_n(p_current, min(6, wLen - (p_current - p_start)), 0x10);
-                        while (size_t(p_current - p_start) < wLen && p_current[0] != 3 && p_current[0] != '|') {
-                            p_current++;
-                        }
-                        if (size_t(p_current - p_start) < wLen && p_current[0] == '|') {
-                            if (size_t(p_current - p_start) + 1 < wLen) {
-                                p_current++;
-                                new_colour_selected
-                                    = mmh::strtoul_n(p_current, min(6, wLen - (p_current - p_start)), 0x10);
-                                have_selected = true;
-                            } else
-                                break; // unexpected eos, malformed string
+                bool have_selected = false;
 
-                            while (size_t(p_current - p_start) < wLen && p_current[0] != 3)
-                                p_current++;
-                        }
+                if (p_current[1] == 3) {
+                    new_colour = new_colour_selected = default_color;
+                    have_selected = true;
+                    p_current += 2;
+                } else {
+                    p_current++;
+                    new_colour = mmh::strtoul_n(p_current, min(6, wLen - (p_current - p_start)), 0x10);
+                    while (size_t(p_current - p_start) < wLen && p_current[0] != 3 && p_current[0] != '|') {
                         p_current++;
                     }
-                    if (selected)
-                        new_colour = have_selected ? new_colour_selected : 0xFFFFFF - new_colour;
+                    if (size_t(p_current - p_start) < wLen && p_current[0] == '|') {
+                        if (size_t(p_current + 1 - p_start) >= wLen)
+                            // unexpected eos, malformed string
+                            break;
 
-                    b_lastColourUsed = false;
-                    cr_last = (cr_current = new_colour);
+                        p_current++;
+                        new_colour_selected = mmh::strtoul_n(p_current, min(6, wLen - (p_current - p_start)), 0x10);
+                        have_selected = true;
+
+                        while (size_t(p_current - p_start) < wLen && p_current[0] != 3)
+                            p_current++;
+                    }
+                    p_current++;
                 }
-            } else
-                break; // unexpected eos, malformed string
-        }
-    }
+                if (selected)
+                    new_colour = have_selected ? new_colour_selected : 0xFFFFFF - new_colour;
 
-    RECT clip = *base_clip;
-    RECT ellipsis = {0, 0, 0, 0};
-
-    t_size i;
-    t_size colourChangeCount = colourChanges.get_count();
-    int widthTotal = 0;
-    int availableWidth = clip.right - clip.left - x_offset;
-
-    src = src_s.get_ptr();
-    wLen = src_s.get_size();
-
-    pfc::array_staticsize_t<UniscribeTextRenderer> scriptStrings(colourChangeCount);
-    pfc::array_staticsize_t<int> characterExtents(wLen);
-
-    for (i = 0; i < colourChangeCount; i++) {
-        t_size thisWLen = colourChanges[i].length;
-        if (thisWLen) {
-            const wchar_t* thisWStr = &src[colourChanges[i].index];
-            scriptStrings[i].analyse(dc, thisWStr, thisWLen, /*availableWidth - widthTotal*/ -1, false);
-            scriptStrings[i].get_character_logical_extents(&characterExtents[colourChanges[i].index],
-                i && colourChanges[i].index ? characterExtents[colourChanges[i].index - 1] : 0);
-            widthTotal += scriptStrings[i].get_output_width();
-            if (widthTotal > availableWidth) {
-                colourChangeCount = i + 1;
-                break;
+                cr_last = (cr_current = new_colour);
             }
         }
     }
 
-    COLORREF cr_old = GetTextColor(dc);
+    RECT clip = *base_clip;
 
-    SetTextAlign(dc, TA_LEFT);
-    SetBkMode(dc, TRANSPARENT);
-    // if (b_set_default_colours)
-    //    SetTextColor(dc, default_color);
+    int available_width = clip.right - clip.left - x_offset;
 
-    int position = clip.left; // item.left+BORDER;
+    int cumulative_width{};
+    for (auto iter = segments.begin(); iter != segments.end(); ++iter) {
+        auto& segment = *iter;
 
-    if (show_ellipsis) {
-        if (widthTotal > availableWidth) {
-            int ellipsis_width = get_text_width(dc, ELLIPSIS, ELLIPSIS_LEN) + 2;
-            if (ellipsis_width <= clip.right - clip.left - x_offset) {
-                for (i = wLen; i; i--) {
-                    if (colourChangeCount && colourChanges[colourChangeCount - 1].length == 0) {
-                        colourChangeCount--;
-                    } else if ((i > 2 && characterExtents[i - 2] + ellipsis_width <= availableWidth) || i == 1) {
-                        src_s[i - 1] = 0x2026;
-                        src_s.set_size(i);
-                        src = src_s.get_ptr();
-                        wLen = i;
-                        if (colourChangeCount) {
-                            widthTotal -= scriptStrings[colourChangeCount - 1].get_output_width();
-                            scriptStrings[colourChangeCount - 1].analyse(dc,
-                                &src[colourChanges[colourChangeCount - 1].index],
-                                colourChanges[colourChangeCount - 1].length, -1, false);
-                            widthTotal += scriptStrings[colourChangeCount - 1].get_output_width();
-                        }
-                        break;
-                    } else if (colourChangeCount && colourChanges[colourChangeCount - 1].index == i - 1) {
-                        colourChangeCount--;
-                        widthTotal -= scriptStrings[colourChangeCount].get_output_width();
-                    } else if (colourChangeCount) {
-                        colourChanges[colourChangeCount - 1].length
-                            = i - colourChanges[colourChangeCount - 1].index - 1;
+        segment.left_offset = cumulative_width;
+        segment.analyse(dc);
+        cumulative_width += segment.renderer.get_output_width();
+
+        if (cumulative_width > available_width) {
+            segments.resize(std::distance(segments.begin(), iter + 1));
+            break;
+        }
+    }
+
+    int position = clip.left;
+
+    if (show_ellipsis && cumulative_width > available_width) {
+        const auto ellipsis_width = get_text_width(dc, ELLIPSIS, ELLIPSIS_LEN) + 2;
+
+        if (ellipsis_width <= clip.right - clip.left - x_offset) {
+            for (auto segment_iter = segments.rbegin(); segment_iter != segments.rend(); ++segment_iter) {
+                auto& segment = *segment_iter;
+
+                const auto truncated = [&] {
+                    for (auto text_iter = segment.text.rbegin(); text_iter != segment.text.rend(); ++text_iter) {
+                        const auto index = std::distance(text_iter, segment.text.rend()) - 1;
+
+                        if (segment.character_right_offsets[index] + ellipsis_width > available_width)
+                            continue;
+
+                        segment.text.resize(index + 1);
+                        segment.text.push_back(0x2026);
+                        segment.analyse(dc);
+
+                        segments.resize(std::distance(segment_iter, segments.rend()));
+                        return true;
                     }
-                }
+                    return false;
+                }();
+
+                if (truncated)
+                    break;
             }
         }
     }
 
     if (align == ALIGN_CENTRE) {
-        position += (clip.right - clip.left - widthTotal) / 2;
+        position += (clip.right - clip.left - cumulative_width) / 2;
     } else if (align == ALIGN_RIGHT) {
-        position += (clip.right - clip.left - widthTotal - x_offset);
+        position += (clip.right - clip.left - cumulative_width - x_offset);
     } else {
         position += x_offset;
     }
 
     if (p_width)
         *p_width = NULL;
-    for (i = 0; i < colourChangeCount; i++) {
-        SetTextColor(dc, colourChanges[i].colour);
-        scriptStrings[i].text_out(position, pos_y, ETO_CLIPPED, &clip);
-        int thisWidth = scriptStrings[i].get_output_width();
+
+    COLORREF cr_old = GetTextColor(dc);
+    SetTextAlign(dc, TA_LEFT);
+    SetBkMode(dc, TRANSPARENT);
+
+    for (auto&& segment : segments) {
+        SetTextColor(dc, segment.colour);
+        segment.renderer.text_out(position, pos_y, ETO_CLIPPED, &clip);
+        int thisWidth = segment.renderer.get_output_width();
         position += thisWidth;
         if (p_width)
             *p_width += thisWidth;
@@ -349,8 +335,8 @@ BOOL text_out_colours_ellipsis(HDC dc, const char* src_c, int src_c_len, int x_o
 
     if (b_set_default_colours)
         SetTextColor(dc, cr_old);
-    else if (!b_lastColourUsed)
-        SetTextColor(dc, cr_last);
+    else if (cr_last)
+        SetTextColor(dc, *cr_last);
 
     return TRUE;
 }


### PR DESCRIPTION
`text_out_colours_ellipsis()` had a number of bugs breaking the use of ellipses for truncated text when embedded colour codes were used.

This rewrites part of `text_out_colours_ellipsis()` to fix these bugs (and make the logic easier to follow at the same time).

(More could still be done to improve the function, but that is out of scope for this change.)

(Note that some of the lines changed contain only white-space changes.)