### PR TITLE
Add support for Ctrl-A in list view inline edit control

### DIFF
--- a/list_view/list_view_inline_edit.cpp
+++ b/list_view/list_view_inline_edit.cpp
@@ -74,6 +74,13 @@ LRESULT ListView::on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM l
         break;
     case WM_GETDLGCODE:
         return CallWindowProc(m_proc_inline_edit, wnd, msg, wp, lp) | DLGC_WANTALLKEYS;
+    case WM_CHAR:
+        // Note: The Edit control on Windows 10 1809 and newer also processes Ctrl-A in WM_CHAR
+        if (!(HIWORD(lp) & KF_REPEAT) && wp == 1 && (GetKeyState(VK_CONTROL) & KF_UP)) {
+            Edit_SetSel(wnd, 0, -1);
+            return 0;
+        }
+        break;
     case WM_KEYDOWN:
         switch (wp) {
         case VK_TAB: {


### PR DESCRIPTION
This adds support for the Ctrl-A (select all) keyboard shortcut in the edit control used for inline editing in the list view.

Note that Windows 10 1809 also processes this natively in WM_CHAR. This also overrides that behaviour to avoid double-processing.