### PR TITLE
Avoid crash in ole::set_drop_description() with long string

### DIFF
--- a/ole.cpp
+++ b/ole.cpp
@@ -131,8 +131,8 @@ HRESULT set_drop_description(IDataObject* pdtobj, DROPIMAGETYPE dit, const char*
             || wcscmp(dd_prev.szMessage, wmsg)) {
             DROPDESCRIPTION dd;
             dd.type = dit;
-            wcscpy_s(dd.szMessage, wmsg.get_ptr());
-            wcscpy_s(dd.szInsert, winsert.get_ptr());
+            wcsncpy_s(dd.szMessage, wmsg.get_ptr(), _TRUNCATE);
+            wcsncpy_s(dd.szInsert, winsert.get_ptr(), _TRUNCATE);
             return set_blob(pdtobj, get_clipboard_format_drop_description(), &dd, sizeof(dd));
         }
         return S_OK;

--- a/win32_helpers.cpp
+++ b/win32_helpers.cpp
@@ -275,31 +275,6 @@ HRESULT get_comctl32_version(DLLVERSIONINFO2& p_dvi)
     return rv;
 }
 
-BOOL shell_notify_icon_simple(DWORD dwMessage, HWND wnd, UINT id, UINT callbackmsg, HICON icon, const char* tip,
-    const char* balloon_title, const char* balloon_msg)
-{
-    // param_utf16_from_utf8 wtip(tip), wbtitle(balloon_title), wbmsg(balloon_msg);
-    NOTIFYICONDATA nid;
-    memset(&nid, 0, sizeof(nid));
-
-    nid.cbSize = NOTIFYICONDATA_V2_SIZE;
-    nid.hWnd = wnd;
-    nid.uID = id;
-    nid.uCallbackMessage = callbackmsg;
-    nid.hIcon = icon;
-    nid.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE | (balloon_msg ? NIF_INFO : NULL);
-    if (tip)
-        wcscpy_s(nid.szTip, pfc::stringcvt::string_wide_from_utf8(tip).get_ptr());
-    if (balloon_title)
-        wcscpy_s(nid.szInfoTitle, pfc::stringcvt::string_wide_from_utf8(balloon_title).get_ptr());
-    if (balloon_msg)
-        wcscpy_s(nid.szInfo, pfc::stringcvt::string_wide_from_utf8(balloon_msg).get_ptr());
-    nid.uTimeout = 10000;
-    nid.dwInfoFlags = NIIF_INFO;
-
-    return Shell_NotifyIcon(dwMessage, &nid);
-}
-
 BOOL run_action(DWORD action, NOTIFYICONDATA* data)
 {
     if (Shell_NotifyIcon(action, data))

--- a/win32_helpers.h
+++ b/win32_helpers.h
@@ -64,8 +64,6 @@ int combo_box_find_item_by_data(HWND wnd, t_size id);
 int rebar_find_item_by_id(HWND wnd, unsigned id);
 void rebar_show_all_bands(HWND wnd);
 
-BOOL shell_notify_icon_simple(DWORD dwMessage, HWND wnd, UINT id, UINT callbackmsg, HICON icon, const char* tip,
-    const char* balloon_title = nullptr, const char* balloon_msg = nullptr);
 BOOL shell_notify_icon(DWORD action, HWND wnd, UINT id, UINT version, UINT callbackmsg, HICON icon, const char* tip);
 BOOL shell_notify_icon_ex(DWORD action, HWND wnd, UINT id, UINT callbackmsg, HICON icon, const char* tip,
     const char* balloon_title, const char* balloon_msg);


### PR DESCRIPTION
This changes `ole::set_drop_description()` to truncate long strings to avoid a crash from an invalid parameter exception raised by `wcscpy_s()`.

(The unused function `shell_notify_icon_simple()`, which had a similar bug, is also removed.)