### PR TITLE
Replace some usages of pfc containers in ListView

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -152,8 +152,8 @@ public:
     HWND get_wnd() const { return m_container_window->get_wnd(); }
 
     unsigned calculate_header_height();
-    void set_columns(const pfc::list_base_const_t<Column>& columns);
-    void set_column_widths(const pfc::list_base_const_t<int>& widths);
+    void set_columns(std::vector<Column> columns);
+    void set_column_widths(std::vector<int> widths);
     void set_group_count(t_size count, bool b_update_columns = true);
 
     t_size get_group_count() const { return m_group_count; }

--- a/list_view/list_view_columns.cpp
+++ b/list_view/list_view_columns.cpp
@@ -33,12 +33,9 @@ uih::alignment ListView::get_column_alignment(t_size index)
     return ret;
 }
 
-void ListView::set_columns(const pfc::list_base_const_t<Column>& columns)
+void ListView::set_columns(std::vector<Column> columns)
 {
-    reset_columns();
-    for (size_t i{}; i < columns.get_count(); ++i) {
-        m_columns.emplace_back(columns[i]);
-    }
+    m_columns = std::move(columns);
 
     update_column_sizes();
 
@@ -49,9 +46,9 @@ void ListView::set_columns(const pfc::list_base_const_t<Column>& columns)
     }
 }
 
-void ListView::set_column_widths(const pfc::list_base_const_t<int>& widths)
+void ListView::set_column_widths(std::vector<int> widths)
 {
-    assert(m_columns.size() == widths.get_count());
+    assert(m_columns.size() == widths.size());
     for (size_t i{}; i < m_columns.size(); ++i)
         m_columns[i].m_size = widths[i];
 


### PR DESCRIPTION
This replaces some usages of `const pfc::list_base_const_t<ListView::Column>&` with `std::vector<ListView::Column>`.