### PR TITLE
Disable tab columns in default list view renderer by default

### DIFF
--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -242,7 +242,7 @@ void lv::DefaultRenderer::render_group(RendererContext context, size_t item_inde
     render_group_background(context, &rc);
     uih::text_out_colours_tab(context.dc, text.data(), text.size(),
         uih::scale_dpi_value(1) + indentation * gsl::narrow<int>(level), uih::scale_dpi_value(3), &rc, false, cr, false,
-        false, true, uih::ALIGN_LEFT, nullptr, true, true, &text_right);
+        true, uih::ALIGN_LEFT, nullptr, true, true, &text_right);
 
     auto line_height = scale_dpi_value(1);
     auto line_top = rc.top + RECT_CY(rc) / 2 - line_height / 2;
@@ -304,7 +304,7 @@ void lv::DefaultRenderer::render_item(RendererContext context, t_size index, std
         rc_subitem.right = rc_subitem.left + sub_item.width;
         text_out_colours_tab(context.dc, sub_item.text.data(), sub_item.text.size(),
             scale_dpi_value(1) + (column_index == 0 ? indentation : 0), scale_dpi_value(3), &rc_subitem, b_selected,
-            cr_text, true, true, true, sub_item.alignment);
+            cr_text, true, true, sub_item.alignment);
         rc_subitem.left = rc_subitem.right;
     }
 

--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -304,7 +304,7 @@ void lv::DefaultRenderer::render_item(RendererContext context, t_size index, std
         rc_subitem.right = rc_subitem.left + sub_item.width;
         text_out_colours_tab(context.dc, sub_item.text.data(), sub_item.text.size(),
             scale_dpi_value(1) + (column_index == 0 ? indentation : 0), scale_dpi_value(3), &rc_subitem, b_selected,
-            cr_text, true, true, sub_item.alignment);
+            cr_text, m_enable_item_tab_columns, true, sub_item.alignment);
         rc_subitem.left = rc_subitem.right;
     }
 

--- a/list_view/list_view_renderer.h
+++ b/list_view/list_view_renderer.h
@@ -50,6 +50,8 @@ public:
 
 class DefaultRenderer : public RendererBase {
 public:
+    DefaultRenderer(bool enable_item_tab_columns = false) : m_enable_item_tab_columns{enable_item_tab_columns} {};
+
     void render_background(RendererContext context, const RECT* rc) override;
 
     void render_group(RendererContext context, size_t item_index, size_t group_index, std::string_view text,
@@ -65,6 +67,9 @@ protected:
     void render_group_background(RendererContext context, const RECT* rc);
 
     void render_focus_rect(RendererContext context, bool should_hide_focus, RECT rc) const;
+
+private:
+    bool m_enable_item_tab_columns{};
 };
 
 } // namespace uih::lv

--- a/text_drawing.cpp
+++ b/text_drawing.cpp
@@ -345,7 +345,7 @@ BOOL text_out_colours_ellipsis(HDC dc, const char* src_c, int src_c_len, int x_o
 }
 
 BOOL text_out_colours_tab(HDC dc, const char* display, int display_len, int left_offset, int border,
-    const RECT* base_clip, bool selected, DWORD default_color, bool columns, bool use_tab, bool show_ellipsis,
+    const RECT* base_clip, bool selected, DWORD default_color, bool enable_tab_columns, bool show_ellipsis,
     alignment align, unsigned* p_width, bool b_set_default_colours, bool b_vertical_align_centre, int* p_position)
 {
     if (!base_clip)
@@ -364,9 +364,7 @@ BOOL text_out_colours_tab(HDC dc, const char* display, int display_len, int left
 
     display_len = pfc::strlen_max(display, display_len);
 
-    columns = use_tab; // always called equal
-
-    if (use_tab) {
+    if (enable_tab_columns) {
         int start = 0;
         int n;
         for (n = 0; n < display_len; n++) {

--- a/text_drawing.h
+++ b/text_drawing.h
@@ -158,7 +158,7 @@ BOOL text_out_colours_ellipsis(HDC dc, const char* src, int len, int x_offset, i
     bool selected, bool show_ellipsis, DWORD default_color, alignment align, unsigned* p_width = nullptr,
     bool b_set_default_colours = true, int* p_position = nullptr);
 BOOL text_out_colours_tab(HDC dc, const char* display, int display_len, int left_offset, int border,
-    const RECT* base_clip, bool selected, DWORD default_color, bool columns, bool tab, bool show_ellipsis,
+    const RECT* base_clip, bool selected, DWORD default_color, bool enable_tab_columns, bool show_ellipsis,
     alignment align, unsigned* p_width = nullptr, bool b_set_default_colours = true,
     bool b_vertical_align_centre = true, int* p_position = nullptr);
 


### PR DESCRIPTION
This disables tab-based columns in the default list view renderer by default but adds a way to configure the renderer to use them for items.

The unused `columns` parameter was also removed from `text_out_colours_tab()`.