### PR TITLE
Tidy up Uniscribe code

### DIFF
--- a/text_drawing.cpp
+++ b/text_drawing.cpp
@@ -49,35 +49,6 @@ unsigned get_text_truncate_point(const char* src, unsigned len)
     return rv;
 }
 
-BOOL CharacterExtentsCalculator::run(HDC dc, const char* text, int length, int max_width, LPINT max_chars,
-    LPINT width_array, LPSIZE sz, unsigned* width_out, bool trunc)
-{
-    const char* src = text;
-
-    if (check_colour_marks(text, length)) {
-        remove_color_marks(text, temp, length);
-        src = temp;
-        length = temp.length();
-    }
-
-    text_w.convert(src, length);
-    UniscribeTextRenderer p_ScriptString;
-    p_ScriptString.analyse(dc, text_w.get_ptr(), text_w.length(), max_width, max_chars != nullptr);
-
-    int _max_chars = p_ScriptString.get_output_character_count();
-    if (width_array)
-        p_ScriptString.get_character_logical_extents(width_array);
-    if (max_chars)
-        *max_chars = _max_chars;
-    if (trunc || width_out) {
-        w_utf8.convert(text_w.get_ptr(), *max_chars);
-        *max_chars = trunc ? get_text_truncate_point(w_utf8, w_utf8.length()) : w_utf8.length();
-        if (width_out)
-            *width_out = get_text_width_colour(dc, w_utf8, *max_chars);
-    }
-    return TRUE;
-}
-
 bool is_rect_null_or_reversed(const RECT* r)
 {
     return r->right <= r->left || r->bottom <= r->top;

--- a/text_drawing.h
+++ b/text_drawing.h
@@ -124,17 +124,6 @@ private:
     static bool m_sdg_valid;
 };
 
-class CharacterExtentsCalculator {
-    pfc::string8_fast_aggressive temp;
-    pfc::stringcvt::string_wide_from_utf8_fast text_w;
-    pfc::stringcvt::string_utf8_from_wide w_utf8;
-
-public:
-    CharacterExtentsCalculator() { temp.prealloc(64); }
-    BOOL run(HDC dc, const char* text, int length, int max_width, LPINT max_chars, LPINT width_array, LPSIZE sz,
-        unsigned* width_out, bool trunc);
-};
-
 enum alignment {
     ALIGN_LEFT,
     ALIGN_CENTRE,

--- a/text_drawing.h
+++ b/text_drawing.h
@@ -14,12 +14,6 @@ public:
         analyse(dc, p_str, p_str_len, max_cx, b_clip);
     }
 
-    UniscribeTextRenderer(HDC dc, const char* p_str, size_t p_str_len, int max_cx, bool b_clip)
-    {
-        initialise();
-        analyse(dc, p_str, p_str_len, max_cx, b_clip);
-    }
-
     void analyse(HDC dc, const wchar_t* p_str, size_t p_str_len, int max_cx, bool b_clip)
     {
         if (m_ssa) {
@@ -31,12 +25,6 @@ public:
             ScriptStringAnalyse(dc, p_str, p_str_len, NULL, -1,
                 SSA_FALLBACK | SSA_GLYPHS | SSA_LINK | (b_clip ? SSA_CLIP : NULL), max_cx, &m_sc, &m_ss, nullptr,
                 nullptr, nullptr, &m_ssa);
-    }
-
-    void analyse(HDC dc, const char* p_str, size_t p_str_len, int max_cx, bool b_clip)
-    {
-        pfc::stringcvt::string_wide_from_utf8 wstr(p_str, p_str_len);
-        analyse(dc, wstr.get_ptr(), wstr.length(), max_cx, b_clip);
     }
 
     void text_out(int x, int y, UINT flags, const RECT* p_rc)

--- a/text_drawing.h
+++ b/text_drawing.h
@@ -36,7 +36,11 @@ public:
     int get_output_character_count()
     {
         const int* len = m_ssa ? ScriptString_pcOutChars(m_ssa) : nullptr; // b_clip = true only
-        return len ? *len : m_string_length;
+
+        if (len && (*len < 0 || gsl::narrow_cast<size_t>(*len) > m_string_length))
+            throw std::length_error("Character count out of range.");
+
+        return len ? *len : gsl::narrow<int>(m_string_length);
     }
 
     void get_output_size(SIZE& p_sz)


### PR DESCRIPTION
This mainly removes unneeded or unused code.

A safety check was also added to `UniscribeTextRenderer::get_output_character_count()`.