### PR TITLE
Remove set_clipboard_data() wrapper function

### DIFF
--- a/win32_helpers.cpp
+++ b/win32_helpers.cpp
@@ -566,7 +566,7 @@ HWND handle_tab_down(HWND wnd)
 bool set_clipboard_text(const char* text, HWND wnd)
 {
     const pfc::stringcvt::string_wide_from_utf8 text_utf16(text);
-    return set_clipboard_data<const wchar_t>(CF_UNICODETEXT, text_utf16.get_ptr(), text_utf16.length() + 1, wnd);
+    return set_clipboard_data<const wchar_t>(CF_UNICODETEXT, {text_utf16.get_ptr(), text_utf16.length() + 1}, wnd);
 }
 
 } // namespace uih

--- a/win32_helpers.h
+++ b/win32_helpers.h
@@ -124,16 +124,6 @@ bool set_clipboard_data(CLIPFORMAT format, gsl::span<Element> data, HWND wnd = n
     return succeeded;
 }
 
-/**
- * Convenience wrapper to handle narrowing conversation as gsl::span<> (currently) has a signed size.
- */
-template <class Element = uint8_t, class Size = size_t>
-bool set_clipboard_data(CLIPFORMAT format, Element* data_ptr, Size data_size, HWND wnd = nullptr)
-{
-    gsl::span<Element> data{data_ptr, gsl::narrow<typename gsl::span<Element>::index_type>(data_size)};
-    return set_clipboard_data(format, data, wnd);
-}
-
 template <typename TInteger>
 class IntegerAndDpi {
 public:


### PR DESCRIPTION
This removes the `set_clipboard_data()` overload that was added to handle `gsl::span`'s signed size.

Newer versions of GSL now have a `gsl::span` with an unsigned size.