### PR TITLE
Fix DPI scaling in handle_modern_background_paint()

### DIFF
--- a/literals.cpp
+++ b/literals.cpp
@@ -1,0 +1,10 @@
+#include "stdafx.h"
+
+namespace uih::literals::spx {
+
+int operator"" _spx(unsigned long long px)
+{
+    return scale_dpi_value(gsl::narrow<int>(px));
+}
+
+} // namespace uih::literals::spx

--- a/literals.h
+++ b/literals.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace uih::literals::spx {
+
+int operator"" _spx(unsigned long long px);
+
+}

--- a/stdafx.h
+++ b/stdafx.h
@@ -54,6 +54,8 @@
 #define RECT_CY(rc) (rc.bottom - rc.top)
 #endif
 
+#include "literals.h"
+
 #include "handle.h"
 #include "win32_helpers.h"
 #include "ole.h"

--- a/ui_helpers.vcxproj
+++ b/ui_helpers.vcxproj
@@ -145,6 +145,7 @@
     <ClInclude Include="handle.h" />
     <ClInclude Include="list_view\list_view.h" />
     <ClInclude Include="list_view\list_view_renderer.h" />
+    <ClInclude Include="literals.h" />
     <ClInclude Include="ole.h" />
     <ClInclude Include="OLE\data_object.h" />
     <ClInclude Include="ole\enum_format_etc.h" />
@@ -247,6 +248,7 @@
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
     </ClCompile>
+    <ClCompile Include="literals.cpp" />
     <ClCompile Include="ole.cpp" />
     <ClCompile Include="ole\data_object.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>

--- a/ui_helpers.vcxproj.filters
+++ b/ui_helpers.vcxproj.filters
@@ -35,6 +35,7 @@
     <ClInclude Include="list_view\list_view_renderer.h">
       <Filter>List View</Filter>
     </ClInclude>
+    <ClInclude Include="literals.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="message_hook.cpp" />
@@ -95,6 +96,7 @@
       <Filter>Data Object</Filter>
     </ClCompile>
     <ClCompile Include="gdi.cpp" />
+    <ClCompile Include="literals.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" />

--- a/win32_helpers.cpp
+++ b/win32_helpers.cpp
@@ -1,5 +1,7 @@
 #include "stdafx.h"
 
+using namespace uih::literals::spx;
+
 class param_utf16_from_utf8 : public pfc::stringcvt::string_wide_from_utf8 {
     bool is_null;
     WORD low_word;
@@ -391,7 +393,10 @@ void rebar_show_all_bands(HWND wnd)
 
 void handle_modern_background_paint(HWND wnd, HWND wnd_button)
 {
-    PAINTSTRUCT ps;
+    const auto padding_height = 11_spx;
+    const auto line_height = 1_spx;
+
+    PAINTSTRUCT ps{};
     HDC dc = BeginPaint(wnd, &ps);
     if (dc) {
         RECT rc_client;
@@ -400,13 +405,13 @@ void handle_modern_background_paint(HWND wnd, HWND wnd_button)
         RECT rc_fill = rc_client;
         if (wnd_button) {
             GetWindowRect(wnd_button, &rc_button);
-            rc_fill.bottom -= RECT_CY(rc_button) + 11;
-            rc_fill.bottom -= 11;
+            MapWindowPoints(HWND_DESKTOP, wnd, reinterpret_cast<LPPOINT>(&rc_button), 2);
+            rc_fill.bottom = rc_button.top - padding_height - line_height / 2;
         }
         FillRect(dc, &rc_fill, GetSysColorBrush(COLOR_WINDOW));
         if (wnd_button) {
             rc_fill.top = rc_fill.bottom;
-            rc_fill.bottom += 1;
+            rc_fill.bottom += line_height;
             FillRect(dc, &rc_fill, GetSysColorBrush(COLOR_3DLIGHT));
         }
         rc_fill.top = rc_fill.bottom;


### PR DESCRIPTION
This adds missing DPI scaling to `handle_modern_background_paint()` and improves how it works.

A user-defined literal `_spx` was also added for scaling pixel units according to the current DPI.