### PR TITLE
Adjust list view scroll timer speed

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -707,6 +707,8 @@ public:
     };
 
 private:
+    unsigned calculate_scroll_timer_speed() const;
+
     void create_timer_search();
     void destroy_timer_search();
 

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -624,6 +624,13 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             return 0;
     } break;
     case WM_VSCROLL:
+        // IDropTargetHelper inexplicably sends these messages. They aren't processed to
+        // avoid interfering with the timer usually used by clients.
+        // If this causes problems, the alternative is to let clients disable and enable
+        // processing as needed.
+        if ((LOWORD(wp) == SB_LINEDOWN || LOWORD(wp) == SB_LINEUP) && HIWORD(wp) == 1)
+            return 0;
+
         exit_inline_edit();
         scroll_from_scroll_bar(LOWORD(wp));
         return 0;

--- a/list_view/list_view_scroll.cpp
+++ b/list_view/list_view_scroll.cpp
@@ -190,17 +190,26 @@ void ListView::update_scroll_info(bool b_vertical, bool b_horizontal)
         _update_scroll_info_horizontal();
     }
 }
+
+unsigned ListView::calculate_scroll_timer_speed() const
+{
+    const auto num_visible_items = get_item_area_height() / get_item_height();
+    const auto divisor = (std::max)(num_visible_items - 5, 1);
+    return std::clamp(25 * 15 / divisor, 10, 100);
+}
+
 void ListView::create_timer_scroll_up()
 {
     if (!m_timer_scroll_up) {
-        SetTimer(get_wnd(), TIMER_SCROLL_UP, 10, nullptr);
+        SetTimer(get_wnd(), TIMER_SCROLL_UP, calculate_scroll_timer_speed(), nullptr);
         m_timer_scroll_up = true;
     }
 }
+
 void ListView::create_timer_scroll_down()
 {
     if (!m_timer_scroll_down) {
-        SetTimer(get_wnd(), TIMER_SCROLL_DOWN, 10, nullptr);
+        SetTimer(get_wnd(), TIMER_SCROLL_DOWN, calculate_scroll_timer_speed(), nullptr);
         m_timer_scroll_down = true;
     }
 }


### PR DESCRIPTION
reupen/columns_ui#306

This adjusts the speed of the list view scroll timer used when selecting items or during drag and drag operations so that it's faster when more items fit in the viewable area and slower when fewer fit.

It also attempts to disable automatic scrolling that was being performed by `IDropTargetHelper` which was causing the scrolling speed to be faster than intended.