### PR TITLE
Add initial version of per-monitor DPI helper functions

### DIFF
--- a/dpi.cpp
+++ b/dpi.cpp
@@ -1,0 +1,120 @@
+#include "stdafx.h"
+
+namespace uih::dpi {
+
+BOOL system_parameters_info_for_dpi(unsigned action, unsigned param, void* data, unsigned dpi)
+{
+    using SystemParametersInfoForDpiProc = BOOL(__stdcall*)(UINT, UINT, PVOID, UINT, UINT);
+
+    const wil::unique_hmodule user32(THROW_LAST_ERROR_IF_NULL(LoadLibrary(L"user32.dll")));
+
+    const auto system_parameters_info_for_dpi_proc
+        = reinterpret_cast<SystemParametersInfoForDpiProc>(GetProcAddress(user32.get(), "SystemParametersInfoForDpi"));
+
+    if (!system_parameters_info_for_dpi_proc)
+        return SystemParametersInfo(action, param, data, 0);
+
+    return system_parameters_info_for_dpi_proc(action, param, data, 0, dpi);
+}
+
+[[nodiscard]] int get_system_metrics_for_dpi(int index, unsigned dpi)
+{
+    using GetSystemMetricsForDpiProc = int(__stdcall*)(int, UINT);
+
+    const wil::unique_hmodule user32(THROW_LAST_ERROR_IF_NULL(LoadLibrary(L"user32.dll")));
+
+    const auto get_system_metrics_for_dpi_proc
+        = reinterpret_cast<GetSystemMetricsForDpiProc>(GetProcAddress(user32.get(), "GetSystemMetricsForDpi"));
+
+    if (!get_system_metrics_for_dpi_proc)
+        return GetSystemMetrics(index);
+
+    return get_system_metrics_for_dpi_proc(index, dpi);
+}
+
+[[nodiscard]] unsigned get_dpi_for_window(HWND wnd)
+{
+    using GetDpiForWindowProc = UINT(__stdcall*)(HWND);
+
+    const wil::unique_hmodule user32(THROW_LAST_ERROR_IF_NULL(LoadLibrary(L"user32.dll")));
+
+    const auto get_dpi_for_window_proc
+        = reinterpret_cast<GetDpiForWindowProc>(GetProcAddress(user32.get(), "GetDpiForWindow"));
+
+    if (!get_dpi_for_window_proc)
+        return get_system_dpi_cached().cx;
+
+    return get_dpi_for_window_proc(wnd);
+}
+
+[[nodiscard]] std::unique_ptr<SetThreadDpiAwarenessContextHandle> set_thread_per_monitor_dpi_aware()
+{
+    wil::unique_hmodule user32(THROW_LAST_ERROR_IF_NULL(LoadLibrary(L"user32.dll")));
+
+    const auto set_thread_dpi_awareness_context_proc = reinterpret_cast<SetThreadDpiAwarenessContextProc>(
+        GetProcAddress(user32.get(), "SetThreadDpiAwarenessContext"));
+
+    if (!set_thread_dpi_awareness_context_proc)
+        return {};
+
+    const auto previous_awareness = set_thread_dpi_awareness_context_proc(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+
+    return std::make_unique<SetThreadDpiAwarenessContextHandle>(
+        std::move(user32), set_thread_dpi_awareness_context_proc, previous_awareness);
+}
+
+namespace {
+struct DialogBoxData {
+    std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message;
+    std::unique_ptr<SetThreadDpiAwarenessContextHandle> dpi_awareness_context;
+    std::shared_ptr<DialogBoxData> self;
+};
+
+BOOL WINAPI on_dialog_box_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+{
+    DialogBoxData* data{};
+    if (msg == WM_INITDIALOG) {
+        data = reinterpret_cast<DialogBoxData*>(lp);
+        data->dpi_awareness_context.reset();
+        SetWindowLongPtr(wnd, DWLP_USER, lp);
+    } else {
+        data = reinterpret_cast<DialogBoxData*>(GetWindowLongPtr(wnd, DWLP_USER));
+    }
+
+    const BOOL result = data ? data->on_message(wnd, msg, wp, lp) : FALSE;
+
+    if (msg == WM_NCDESTROY) {
+        assert(data);
+
+        if (data)
+            data->self.reset();
+
+        SetWindowLongPtr(wnd, DWLP_USER, NULL);
+    }
+
+    return result;
+}
+
+} // namespace
+
+INT_PTR modal_dialog_box(
+    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
+{
+    const auto data = std ::make_unique<DialogBoxData>(
+        DialogBoxData{std::move(on_message), set_thread_per_monitor_dpi_aware(), {}});
+
+    return DialogBoxParam(mmh::get_current_instance(), MAKEINTRESOURCE(resource_id), wnd, on_dialog_box_message,
+        reinterpret_cast<LPARAM>(data.get()));
+}
+
+HWND modeless_dialog_box(
+    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
+{
+    std::shared_ptr<DialogBoxData> data = std ::make_shared<DialogBoxData>(
+        DialogBoxData{std::move(on_message), set_thread_per_monitor_dpi_aware(), {}});
+    data->self = data;
+
+    return CreateDialogParam(mmh::get_current_instance(), MAKEINTRESOURCE(resource_id), wnd, on_dialog_box_message,
+        reinterpret_cast<LPARAM>(data.get()));
+}
+} // namespace uih::dpi

--- a/dpi.h
+++ b/dpi.h
@@ -1,0 +1,59 @@
+#pragma once
+
+namespace uih::dpi {
+
+using SetThreadDpiAwarenessContextProc = DPI_AWARENESS_CONTEXT(__stdcall*)(DPI_AWARENESS_CONTEXT);
+
+class SetThreadDpiAwarenessContextHandle {
+public:
+    SetThreadDpiAwarenessContextHandle() = default;
+
+    SetThreadDpiAwarenessContextHandle(SetThreadDpiAwarenessContextHandle&) = delete;
+    SetThreadDpiAwarenessContextHandle& operator=(SetThreadDpiAwarenessContextHandle&) = delete;
+
+    SetThreadDpiAwarenessContextHandle(SetThreadDpiAwarenessContextHandle&&) = default;
+    SetThreadDpiAwarenessContextHandle& operator=(SetThreadDpiAwarenessContextHandle&&) = default;
+
+    SetThreadDpiAwarenessContextHandle(wil::unique_hmodule&& user32,
+        SetThreadDpiAwarenessContextProc set_thread_dpi_awareness_context, DPI_AWARENESS_CONTEXT previous_awareness)
+        : m_user32(std::move(user32))
+        , m_set_thread_dpi_awareness_context(set_thread_dpi_awareness_context)
+        , m_previous_awareness(previous_awareness)
+    {
+    }
+
+    ~SetThreadDpiAwarenessContextHandle()
+    {
+        if (m_set_thread_dpi_awareness_context)
+            m_set_thread_dpi_awareness_context(m_previous_awareness);
+    }
+
+private:
+    wil::unique_hmodule m_user32;
+    SetThreadDpiAwarenessContextProc m_set_thread_dpi_awareness_context{};
+    DPI_AWARENESS_CONTEXT m_previous_awareness{};
+};
+
+BOOL system_parameters_info_for_dpi(unsigned action, unsigned param, void* data, unsigned dpi);
+
+[[nodiscard]] int get_system_metrics_for_dpi(int index, unsigned dpi);
+
+[[nodiscard]] unsigned get_dpi_for_window(HWND wnd);
+
+[[nodiscard]] std::unique_ptr<SetThreadDpiAwarenessContextHandle> set_thread_per_monitor_dpi_aware();
+
+/*
+ * Per monitor DPI-aware version of DialogBox() (for modal dialogs).
+ * Making DialogBox() per-monitor DPI-aware is more complicated as DialogBox() blocks and has its own message
+ * loop, while the DPI-awareness context needs to be reset straight away.
+ */
+INT_PTR modal_dialog_box(
+    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message);
+
+/**
+ * Per monitor DPI-aware version of CreateDialog() (for modeless dialogs).
+ */
+HWND modeless_dialog_box(
+    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message);
+
+} // namespace uih::dpi

--- a/stdafx.h
+++ b/stdafx.h
@@ -19,6 +19,8 @@
 // Included before windows.h, because pfc.h includes winsock2.h
 #include "../pfc/pfc.h"
 
+#include <wil/resource.h>
+
 #include <windows.h>
 #include <WindowsX.h>
 #include <SHLWAPI.H>
@@ -60,6 +62,7 @@
 #include "win32_helpers.h"
 #include "ole.h"
 
+#include "dpi.h"
 #include "container_window.h"
 #include "message_hook.h"
 #include "trackbar.h"

--- a/ui_helpers.vcxproj
+++ b/ui_helpers.vcxproj
@@ -137,6 +137,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="container_window.h" />
+    <ClInclude Include="dpi.h" />
     <ClInclude Include="drag_image.h" />
     <ClInclude Include="handle.h" />
     <ClInclude Include="list_view\list_view.h" />
@@ -158,6 +159,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="container_window.cpp" />
+    <ClCompile Include="dpi.cpp" />
     <ClCompile Include="drag_image.cpp" />
     <ClCompile Include="gdi.cpp" />
     <ClCompile Include="list_view\list_view_columns.cpp">

--- a/ui_helpers.vcxproj.filters
+++ b/ui_helpers.vcxproj.filters
@@ -36,6 +36,7 @@
       <Filter>List View</Filter>
     </ClInclude>
     <ClInclude Include="literals.h" />
+    <ClInclude Include="dpi.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="message_hook.cpp" />
@@ -97,6 +98,7 @@
     </ClCompile>
     <ClCompile Include="gdi.cpp" />
     <ClCompile Include="literals.cpp" />
+    <ClCompile Include="dpi.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" />


### PR DESCRIPTION
reupen/columns_ui#353

This adds a few initial helper functions for making windows and dialogue boxes support per-monitor DPI on Windows 10 1607 and newer.

These can be considered experimental for the minute.