### PR TITLE
Add non-per monitor DPI aware versions of dialog utilities

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -1,0 +1,56 @@
+#include "stdafx.h"
+
+namespace uih {
+
+namespace {
+struct DialogBoxData {
+    std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message;
+    std::shared_ptr<DialogBoxData> self;
+};
+
+BOOL WINAPI on_dialog_box_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+{
+    DialogBoxData* data{};
+    if (msg == WM_INITDIALOG) {
+        data = reinterpret_cast<DialogBoxData*>(lp);
+        SetWindowLongPtr(wnd, DWLP_USER, lp);
+    } else {
+        data = reinterpret_cast<DialogBoxData*>(GetWindowLongPtr(wnd, DWLP_USER));
+    }
+
+    const BOOL result = data ? data->on_message(wnd, msg, wp, lp) : FALSE;
+
+    if (msg == WM_NCDESTROY) {
+        assert(data);
+
+        if (data)
+            data->self.reset();
+
+        SetWindowLongPtr(wnd, DWLP_USER, NULL);
+    }
+
+    return result;
+}
+
+} // namespace
+
+INT_PTR modal_dialog_box(
+    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
+{
+    const auto data = std ::make_unique<DialogBoxData>(DialogBoxData{std::move(on_message), {}});
+
+    return DialogBoxParam(mmh::get_current_instance(), MAKEINTRESOURCE(resource_id), wnd, on_dialog_box_message,
+        reinterpret_cast<LPARAM>(data.get()));
+}
+
+HWND modeless_dialog_box(
+    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
+{
+    std::shared_ptr<DialogBoxData> data = std ::make_shared<DialogBoxData>(DialogBoxData{std::move(on_message), {}});
+    data->self = data;
+
+    return CreateDialogParam(mmh::get_current_instance(), MAKEINTRESOURCE(resource_id), wnd, on_dialog_box_message,
+        reinterpret_cast<LPARAM>(data.get()));
+}
+
+} // namespace uih

--- a/dialog.h
+++ b/dialog.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace uih {
+
+INT_PTR modal_dialog_box(
+    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message);
+
+HWND modeless_dialog_box(
+    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message);
+
+} // namespace uih

--- a/dpi.h
+++ b/dpi.h
@@ -42,9 +42,9 @@ BOOL system_parameters_info_for_dpi(unsigned action, unsigned param, void* data,
 
 [[nodiscard]] unsigned get_dpi_for_window(HWND wnd);
 
-[[nodiscard]] std::unique_ptr<SetThreadDpiAwarenessContextHandle> set_thread_per_monitor_dpi_aware();
+[[nodiscard]] std::shared_ptr<SetThreadDpiAwarenessContextHandle> set_thread_per_monitor_dpi_aware();
 
-[[nodiscard]] std::unique_ptr<SetThreadDpiAwarenessContextHandle> reset_thread_per_monitor_dpi_awareness();
+[[nodiscard]] std::shared_ptr<SetThreadDpiAwarenessContextHandle> reset_thread_per_monitor_dpi_awareness();
 
 template <class Function>
 auto with_default_thread_dpi_awareness(Function&& function)
@@ -53,7 +53,7 @@ auto with_default_thread_dpi_awareness(Function&& function)
     return function();
 }
 
-[[nodiscard]] std::unique_ptr<SetThreadDpiHostingBehaviorHandle> set_thread_mixed_dpi_hosting();
+[[nodiscard]] std::shared_ptr<SetThreadDpiHostingBehaviorHandle> set_thread_mixed_dpi_hosting();
 
 /*
  * Per monitor DPI-aware version of DialogBox() (for modal dialogs).

--- a/stdafx.h
+++ b/stdafx.h
@@ -62,6 +62,7 @@
 #include "win32_helpers.h"
 #include "ole.h"
 
+#include "dialog.h"
 #include "dpi.h"
 #include "container_window.h"
 #include "message_hook.h"

--- a/ui_helpers.vcxproj
+++ b/ui_helpers.vcxproj
@@ -137,6 +137,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="container_window.h" />
+    <ClInclude Include="dialog.h" />
     <ClInclude Include="dpi.h" />
     <ClInclude Include="drag_image.h" />
     <ClInclude Include="handle.h" />
@@ -159,6 +160,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="container_window.cpp" />
+    <ClCompile Include="dialog.cpp" />
     <ClCompile Include="dpi.cpp" />
     <ClCompile Include="drag_image.cpp" />
     <ClCompile Include="gdi.cpp" />

--- a/ui_helpers.vcxproj.filters
+++ b/ui_helpers.vcxproj.filters
@@ -37,6 +37,7 @@
     </ClInclude>
     <ClInclude Include="literals.h" />
     <ClInclude Include="dpi.h" />
+    <ClInclude Include="dialog.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="message_hook.cpp" />
@@ -99,6 +100,7 @@
     <ClCompile Include="gdi.cpp" />
     <ClCompile Include="literals.cpp" />
     <ClCompile Include="dpi.cpp" />
+    <ClCompile Include="dialog.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" />


### PR DESCRIPTION
This adds non-per monitor DPI aware versions of `modeless_dialog_box()` and `modal_dialog_box()`, and updates the per-monitor DPI aware versions to use them.