### PR TITLE
Enable vcpkg manifest mode and remove use of pfc::string_simple_t

### DIFF
--- a/solid_fill.h
+++ b/solid_fill.h
@@ -28,8 +28,9 @@ public:
             CloseThemeData(m_theme);
         m_theme = nullptr;
         if (m_container_window->get_wnd()) {
-            m_theme = IsThemeActive() && IsAppThemed() ? OpenThemeData(m_container_window->get_wnd(), m_theme_class)
-                                                       : nullptr;
+            m_theme = IsThemeActive() && IsAppThemed()
+                ? OpenThemeData(m_container_window->get_wnd(), m_theme_class.c_str())
+                : nullptr;
             redraw();
         }
     }
@@ -43,8 +44,9 @@ public:
             CloseThemeData(m_theme);
         m_theme = nullptr;
         if (m_container_window->get_wnd()) {
-            m_theme = IsThemeActive() && IsAppThemed() ? OpenThemeData(m_container_window->get_wnd(), m_theme_class)
-                                                       : nullptr;
+            m_theme = IsThemeActive() && IsAppThemed()
+                ? OpenThemeData(m_container_window->get_wnd(), m_theme_class.c_str())
+                : nullptr;
             redraw();
         }
     }
@@ -77,7 +79,7 @@ private:
         switch (msg) {
         case WM_CREATE: {
             if (m_mode == mode_theme_fill || m_mode == mode_theme_solid_fill)
-                m_theme = IsThemeActive() && IsAppThemed() ? OpenThemeData(wnd, m_theme_class) : nullptr;
+                m_theme = IsThemeActive() && IsAppThemed() ? OpenThemeData(wnd, m_theme_class.c_str()) : nullptr;
             SetWindowTheme(wnd, L"Explorer", nullptr);
         } break;
         case WM_DESTROY: {
@@ -90,7 +92,7 @@ private:
                 CloseThemeData(m_theme);
             m_theme = nullptr;
             if (m_mode == mode_theme_fill || m_mode == mode_theme_solid_fill)
-                m_theme = (IsThemeActive() && IsAppThemed()) ? OpenThemeData(wnd, m_theme_class) : nullptr;
+                m_theme = (IsThemeActive() && IsAppThemed()) ? OpenThemeData(wnd, m_theme_class.c_str()) : nullptr;
             redraw();
         } break;
         case WM_ENABLE:
@@ -131,7 +133,7 @@ private:
     };
 
     Mode m_mode{mode_solid_fill};
-    pfc::string_simple_t<WCHAR> m_theme_class;
+    std::wstring m_theme_class;
     COLORREF m_fill_colour = NULL;
     HTHEME m_theme = nullptr;
     int m_theme_part = NULL;

--- a/ui_helpers.vcxproj
+++ b/ui_helpers.vcxproj
@@ -70,6 +70,21 @@
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Configuration)\$(ProjectName)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <VcpkgUseStatic>true</VcpkgUseStatic>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <VcpkgUseStatic>true</VcpkgUseStatic>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <VcpkgUseStatic>true</VcpkgUseStatic>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <VcpkgUseStatic>true</VcpkgUseStatic>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>


### PR DESCRIPTION
This:

- removes a use of `pfc::string_simple_t<wchar_t>`
- enables vcpkg manifest support in the VS project

Vcpkg manifest mode should make handling of dependencies easier. Currently, a manifest in the parent project is relied on (rather than including a manifest here).