### PR TITLE
Don't set list view header window theme in non-dark mode

### DIFF
--- a/list_view/list_view_header.cpp
+++ b/list_view/list_view_header.cpp
@@ -23,7 +23,7 @@ void ListView::create_header()
                     | (m_allow_header_rearrange ? HDS_DRAGDROP : NULL) | HDS_HORZ | HDS_FULLDRAG
                     | (m_sorting_enabled ? HDS_BUTTONS : 0) | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
                 0, 0, 0, 0, get_wnd(), HMENU(IDC_HEADER), mmh::get_current_instance(), nullptr);
-            SetWindowTheme(m_wnd_header, m_use_dark_mode ? L"DarkMode_ItemsView" : L"ItemsView", nullptr);
+            SetWindowTheme(m_wnd_header, m_use_dark_mode ? L"DarkMode_ItemsView" : nullptr, nullptr);
             SendMessage(m_wnd_header, WM_SETFONT, (WPARAM)m_header_font.get(), MAKELPARAM(FALSE, 0));
             if (m_initialised) {
                 build_header();


### PR DESCRIPTION
This stops applying the ItemsView window theme to the list view header to fix a bug where the header background is the wrong colour after the last column.