### PR TITLE
Correct various integer types

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -4,11 +4,11 @@ namespace uih {
 
 namespace {
 struct DialogBoxData {
-    std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message;
+    std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message;
     std::shared_ptr<DialogBoxData> self;
 };
 
-BOOL WINAPI on_dialog_box_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+INT_PTR WINAPI on_dialog_box_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     DialogBoxData* data{};
     if (msg == WM_INITDIALOG) {
@@ -18,7 +18,7 @@ BOOL WINAPI on_dialog_box_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         data = reinterpret_cast<DialogBoxData*>(GetWindowLongPtr(wnd, DWLP_USER));
     }
 
-    const BOOL result = data ? data->on_message(wnd, msg, wp, lp) : FALSE;
+    const auto result = data ? data->on_message(wnd, msg, wp, lp) : FALSE;
 
     if (msg == WM_NCDESTROY) {
         assert(data);
@@ -35,7 +35,7 @@ BOOL WINAPI on_dialog_box_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 } // namespace
 
 INT_PTR modal_dialog_box(
-    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
+    UINT resource_id, HWND wnd, std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
 {
     const auto data = std ::make_unique<DialogBoxData>(DialogBoxData{std::move(on_message), {}});
 
@@ -44,7 +44,7 @@ INT_PTR modal_dialog_box(
 }
 
 HWND modeless_dialog_box(
-    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
+    UINT resource_id, HWND wnd, std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
 {
     std::shared_ptr<DialogBoxData> data = std ::make_shared<DialogBoxData>(DialogBoxData{std::move(on_message), {}});
     data->self = data;

--- a/dialog.h
+++ b/dialog.h
@@ -3,9 +3,9 @@
 namespace uih {
 
 INT_PTR modal_dialog_box(
-    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message);
+    UINT resource_id, HWND wnd, std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message);
 
 HWND modeless_dialog_box(
-    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message);
+    UINT resource_id, HWND wnd, std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message);
 
 } // namespace uih

--- a/dpi.cpp
+++ b/dpi.cpp
@@ -99,7 +99,7 @@ BOOL system_parameters_info_for_dpi(unsigned action, unsigned param, void* data,
 }
 
 INT_PTR modal_dialog_box(
-    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
+    UINT resource_id, HWND wnd, std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
 {
     auto wrapped_on_message = [on_message = std::move(on_message), dpi_handle = set_thread_per_monitor_dpi_aware()](
                                   auto&& wnd, auto&& msg, auto&& wp, auto&& lp) mutable {
@@ -114,7 +114,7 @@ INT_PTR modal_dialog_box(
 }
 
 HWND modeless_dialog_box(
-    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
+    UINT resource_id, HWND wnd, std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
 {
     auto _ = set_thread_per_monitor_dpi_aware();
 

--- a/dpi.h
+++ b/dpi.h
@@ -61,13 +61,13 @@ auto with_default_thread_dpi_awareness(Function&& function)
  * loop, while the DPI-awareness context needs to be reset straight away.
  */
 INT_PTR modal_dialog_box(
-    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message);
+    UINT resource_id, HWND wnd, std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message);
 
 /**
  * Per monitor DPI-aware version of CreateDialog() (for modeless dialogs).
  */
 HWND modeless_dialog_box(
-    UINT resource_id, HWND wnd, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message);
+    UINT resource_id, HWND wnd, std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message);
 
 int scale_value(unsigned target_dpi, int value, unsigned original_dpi = USER_DEFAULT_SCREEN_DPI);
 

--- a/info_box.h
+++ b/info_box.h
@@ -39,13 +39,10 @@ public:
         GetWindowRect(m_container_window->get_wnd(), &rcw);
         GetClientRect(m_container_window->get_wnd(), &rcwc);
         return get_large_padding() * 6 + uih::scale_dpi_value(1) + RECT_CY(rc) + (RECT_CY(rcw) - RECT_CY(rcwc))
-            + std::max((t_size)get_text_height(), (t_size)get_icon_height());
+            + std::max(get_text_height(), get_icon_height());
     }
 
-    int get_text_height() const
-    {
-        return SendMessage(m_wnd_edit, EM_GETLINECOUNT, 0, 0) * uih::get_font_height(m_font.get());
-    }
+    int get_text_height() const { return Edit_GetLineCount(m_wnd_edit) * uih::get_font_height(m_font.get()); }
 
     int get_icon_height() const
     {

--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -90,7 +90,7 @@ protected:
         std::vector<t_group_ptr> m_groups;
 
         t_size m_display_index{0};
-        t_size m_display_position{0};
+        int m_display_position{0};
         bool m_selected{false};
 
         void update_line_count()
@@ -151,7 +151,7 @@ public:
      */
     HWND get_wnd() const { return m_container_window->get_wnd(); }
 
-    unsigned calculate_header_height();
+    int calculate_header_height();
     void set_columns(std::vector<Column> columns);
     void set_column_widths(std::vector<int> widths);
     void set_group_count(t_size count, bool b_update_columns = true);
@@ -274,7 +274,7 @@ public:
     void get_header_rect(LPRECT rc) const;
 
     /** Current height*/
-    unsigned get_header_height() const;
+    int get_header_height() const;
     [[nodiscard]] RECT get_items_rect() const;
     int get_item_area_height() const;
 
@@ -284,7 +284,7 @@ public:
     }
 
     void get_search_box_rect(LPRECT rc) const;
-    unsigned get_search_box_height() const;
+    int get_search_box_height() const;
 
     void invalidate_all(bool b_children = false);
     void invalidate_items(t_size index, t_size count);
@@ -317,11 +317,11 @@ public:
 
     [[nodiscard]] VerticalHitTestResult vertical_hit_test(int y) const;
 
-    [[nodiscard]] size_t get_item_at_or_before(int y_position) const
+    [[nodiscard]] int get_item_at_or_before(int y_position) const
     {
         return vertical_hit_test(y_position).item_leftmost;
     }
-    [[nodiscard]] size_t get_item_at_or_after(int y_position) const
+    [[nodiscard]] int get_item_at_or_after(int y_position) const
     {
         return vertical_hit_test(y_position).item_rightmost;
     }
@@ -387,7 +387,7 @@ public:
         ret += get_item_position(index, b_include_headers);
         ret += m_item_height - 1;
         if (get_show_group_info_area() && m_group_count) {
-            int gheight = gcount * m_item_height;
+            int gheight = gsl::narrow<int>(gcount) * m_item_height;
             int group_cy = get_group_info_area_total_height();
             if (gheight < group_cy)
                 ret += group_cy - gheight;
@@ -519,7 +519,7 @@ public:
 
     virtual void notify_on_column_size_change(t_size index, int new_width){};
 
-    virtual void notify_on_group_info_area_size_change(t_size new_width){};
+    virtual void notify_on_group_info_area_size_change(int new_width){};
 
     virtual void notify_on_header_rearrange(t_size index_from, t_size index_to){};
 
@@ -726,17 +726,17 @@ private:
     static LRESULT WINAPI g_on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
     LRESULT on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
-    void create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column);
+    void create_inline_edit(const pfc::list_base_const_t<t_size>& indices, size_t column);
     void save_inline_edit();
     void exit_inline_edit();
 
     virtual bool notify_before_create_inline_edit(
-        const pfc::list_base_const_t<t_size>& indices, unsigned column, bool b_source_mouse)
+        const pfc::list_base_const_t<t_size>& indices, size_t column, bool b_source_mouse)
     {
         return false;
     };
 
-    virtual bool notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column,
+    virtual bool notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, size_t column,
         pfc::string_base& p_test, t_size& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries)
     {
         return true;

--- a/list_view/list_view_columns.cpp
+++ b/list_view/list_view_columns.cpp
@@ -89,7 +89,7 @@ void ListView::update_column_sizes()
             total_weight += column.m_autosize_weight;
 
         pfc::array_t<bool> sized;
-        pfc::array_t<t_ssize> deltas;
+        pfc::array_t<int> deltas;
         sized.set_count(count);
         deltas.set_count(count);
         sized.fill_null();
@@ -98,7 +98,7 @@ void ListView::update_column_sizes()
         int width_difference = display_width - width;
 
         while (width_difference && total_weight && sized_count) {
-            t_ssize width_difference_local = width_difference;
+            int width_difference_local = width_difference;
             int total_weight_local = total_weight;
 
             for (size_t i{0}; i < count; i++) {
@@ -111,8 +111,8 @@ void ListView::update_column_sizes()
 
             for (size_t i{0}; i < count; i++) {
                 if (!sized[i]) {
-                    t_ssize delta = deltas[i];
-                    if ((t_ssize)m_columns[i].m_display_size + delta <= 0) {
+                    int delta = deltas[i];
+                    if (m_columns[i].m_display_size + delta <= 0) {
                         total_weight -= m_columns[i].m_autosize_weight;
                         sized[i] = true;
                         sized_count--;

--- a/list_view/list_view_header.cpp
+++ b/list_view/list_view_header.cpp
@@ -85,7 +85,7 @@ void ListView::build_header()
 
         {
             int n;
-            int t = m_columns.size();
+            int t = gsl::narrow<int>(m_columns.size());
             int i = 0;
             const auto indentation = get_total_indentation();
             if (indentation /*m_group_count*/) {
@@ -106,7 +106,7 @@ void ListView::build_header()
                     hdi.fmt |= HDF_CENTER;
                 else if (m_columns[n].m_alignment == uih::ALIGN_RIGHT)
                     hdi.fmt |= HDF_RIGHT;
-                hdi.cchTextMax = m_columns[n].m_title.length();
+                hdi.cchTextMax = gsl::narrow<int>(m_columns[n].m_title.length());
                 wstr.convert(m_columns[n].m_title);
                 hdi.pszText = const_cast<wchar_t*>(wstr.get_ptr());
 
@@ -168,10 +168,9 @@ bool ListView::on_wm_notify_header(LPNMHDR lpnm, LRESULT& ret)
                     HFONT fnt_old = SelectFont(dc, m_items_font.get());
 
                     int w = 0;
-                    int n;
-                    int t = get_item_count();
+                    auto t = get_item_count();
 
-                    for (n = 0; n < t; n++) {
+                    for (size_t n = 0; n < t; n++) {
                         const char* str = get_item_text(n, realIndex);
                         size = uih::get_text_width_colour(dc, str, strlen(str));
                         if (size > w)
@@ -296,7 +295,7 @@ void ListView::get_header_rect(LPRECT rc) const
     }
 }
 
-unsigned ListView::get_header_height() const
+int ListView::get_header_height() const
 {
     unsigned ret = 0;
     if (m_wnd_header) {
@@ -306,7 +305,7 @@ unsigned ListView::get_header_height() const
     }
     return ret;
 }
-unsigned ListView::calculate_header_height()
+int ListView::calculate_header_height()
 {
     unsigned rv = 0;
     if (m_wnd_header) {
@@ -320,15 +319,13 @@ void ListView::update_header()
 {
     if (m_wnd_header) {
         pfc::vartoggle_t<bool> toggle(m_ignore_column_size_change_notification, true);
-        // SendMessage(m_wnd_header, WM_SETREDRAW, FALSE, NULL);
-        t_size i;
-        t_size count = m_columns.size();
-        t_size j = 0;
+        auto count = gsl::narrow<int>(m_columns.size());
+        int j = 0;
         if (m_have_indent_column) {
             uih::header_set_item_width(m_wnd_header, j, get_total_indentation());
             j++;
         }
-        for (i = 0; i < count; i++) {
+        for (int i = 0; i < count; i++) {
             uih::header_set_item_width(m_wnd_header, i + j, m_columns[i].m_display_size);
         }
         // SendMessage(m_wnd_header, WM_SETREDRAW, TRUE, NULL);

--- a/list_view/list_view_hittest.cpp
+++ b/list_view/list_view_hittest.cpp
@@ -8,9 +8,9 @@ void ListView::hit_test_ex(POINT pt_client, ListView::HitTestResult& result)
     const int item_area_height = RECT_CY(rc_item_area);
 
     result.column = pfc_infinite;
-    const t_ssize first_column_left = -m_horizontal_scroll_position + get_total_indentation();
+    const int first_column_left = -m_horizontal_scroll_position + get_total_indentation();
     const t_size column_count = m_columns.size();
-    t_ssize last_column_right = first_column_left;
+    int last_column_right = first_column_left;
 
     for (size_t column_index{0}; column_index < column_count; column_index++) {
         const int left = last_column_right;

--- a/list_view/list_view_inline_edit.cpp
+++ b/list_view/list_view_inline_edit.cpp
@@ -4,7 +4,7 @@ namespace uih {
 
 void ListView::activate_inline_editing(t_size column_start)
 {
-    unsigned count = m_columns.size();
+    size_t count = m_columns.size();
     if (count) {
         t_size focus = get_focus_item();
         if (focus != pfc_infinite) {
@@ -22,7 +22,7 @@ void ListView::activate_inline_editing(t_size column_start)
             if (column_start > count)
                 column_start = 0;
 
-            unsigned column;
+            size_t column;
             for (column = column_start; column < count; column++) {
                 if (notify_before_create_inline_edit(indices, column, false)) {
                     create_inline_edit(indices, column);
@@ -35,7 +35,7 @@ void ListView::activate_inline_editing(t_size column_start)
 
 void ListView::activate_inline_editing(const pfc::list_base_const_t<t_size>& indices, t_size column)
 {
-    unsigned count = m_columns.size();
+    size_t count = m_columns.size();
     if (column < count) {
         if (notify_before_create_inline_edit(indices, column, false)) {
             create_inline_edit(indices, column);
@@ -84,7 +84,7 @@ LRESULT ListView::on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM l
     case WM_KEYDOWN:
         switch (wp) {
         case VK_TAB: {
-            unsigned count = m_columns.size();
+            size_t count = m_columns.size();
             t_size indices_count = m_inline_edit_indices.get_count();
             assert(indices_count);
             if (count && indices_count) {
@@ -171,7 +171,7 @@ LRESULT ListView::on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM l
     return CallWindowProc(m_proc_inline_edit, wnd, msg, wp, lp);
 }
 
-void ListView::create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column)
+void ListView::create_inline_edit(const pfc::list_base_const_t<t_size>& indices, size_t column)
 {
     t_size indices_count = indices.get_count();
     if (!indices_count)
@@ -192,7 +192,7 @@ void ListView::create_inline_edit(const pfc::list_base_const_t<t_size>& indices,
     const auto indices_spread = indices[indices_count - 1] - indices[0] + 1;
     const auto items_top = get_item_position(indices[0]);
     const auto items_bottom = get_item_position_bottom(indices[indices_count - 1]);
-    int indices_total_height = min(items_bottom - items_top, MAXLONG);
+    int indices_total_height = std::min(items_bottom - items_top, MAXLONG);
 
     if (m_timer_inline_edit) {
         KillTimer(get_wnd(), EDIT_TIMER_ID);
@@ -225,7 +225,7 @@ void ListView::create_inline_edit(const pfc::list_base_const_t<t_size>& indices,
         x = get_total_indentation();
 
         unsigned n;
-        unsigned count = m_columns.size();
+        size_t count = m_columns.size();
         for (n = 0; n < count && n < column; n++) {
             x += m_columns[n].m_display_size;
         }
@@ -239,7 +239,7 @@ void ListView::create_inline_edit(const pfc::list_base_const_t<t_size>& indices,
     int header_height = rc_items.top;
 
     int cx = m_columns[column].m_display_size;
-    int cy = min(max(indices_total_height, font_height), rc_items.bottom - rc_items.top);
+    int cy = std::min(std::max(indices_total_height, font_height), gsl::narrow<int>(rc_items.bottom - rc_items.top));
     int y = get_item_position(indices[0]) - m_scroll_position + header_height;
     if (cy > indices_total_height)
         y -= (cy - indices_total_height) / 2;

--- a/list_view/list_view_items.cpp
+++ b/list_view/list_view_items.cpp
@@ -344,7 +344,7 @@ void ListView::__calculate_item_positions(t_size index_start)
     if (index_start >= get_item_count())
         return;
 
-    t_size y_pointer = 0;
+    int y_pointer = 0;
     if (m_group_count)
         while (index_start && get_item_display_group_count(index_start) == 0)
             index_start--;
@@ -358,10 +358,10 @@ void ListView::__calculate_item_positions(t_size index_start)
     }
     t_size i;
     t_size count = m_items.size();
-    t_size group_height_counter = 0;
-    t_size group_minimum_inner_height = get_group_minimum_inner_height();
+    int group_height_counter = 0;
+    const auto group_minimum_inner_height = get_group_minimum_inner_height();
     for (i = index_start; i < count; i++) {
-        t_size groups = get_item_display_group_count(i);
+        const auto groups = gsl::narrow<int>(get_item_display_group_count(i));
         if (groups) {
             if (group_height_counter && group_height_counter < group_minimum_inner_height)
                 y_pointer += group_minimum_inner_height - group_height_counter;

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -77,10 +77,8 @@ void ListView::set_sort_column(t_size index, bool b_direction)
         hdi.mask = HDI_FORMAT;
 
         {
-            int n;
-            int t = m_columns.size();
-            int i = 0;
-            for (n = 0; n < t; n++) {
+            const int t = gsl::narrow<int>(m_columns.size());
+            for (int n = 0; n < t; n++) {
                 Header_GetItem(m_wnd_header, n, &hdi);
                 hdi.fmt &= ~(HDF_SORTUP | HDF_SORTDOWN);
                 if (m_show_sort_indicators && n == headerIndex)
@@ -131,16 +129,15 @@ void ListView::on_size(int cxd, int cyd, bool b_update_scroll)
         RECT rc;
         GetClientRect(get_wnd(), &rc);
         int cx = RECT_CX(rc);
-        int cy = RECT_CY(rc);
 
-        t_size old_search_height = get_search_box_height();
-        t_size new_search_height = m_search_editbox ? m_item_height + scale_dpi_value(4) : 0;
+        auto old_search_height = get_search_box_height();
+        auto new_search_height = m_search_editbox ? m_item_height + scale_dpi_value(4) : 0;
 
         if (m_search_editbox) {
             SetWindowPos(m_search_editbox, nullptr, 0, 0, cx, new_search_height, SWP_NOZORDER);
         }
 
-        t_size new_header_height = calculate_header_height();
+        auto new_header_height = calculate_header_height();
         if (new_header_height != RECT_CY(rc_header) && m_wnd_header)
             // Update height because affects scroll info
             SetWindowPos(m_wnd_header, nullptr, -m_horizontal_scroll_position, new_search_height,
@@ -156,7 +153,6 @@ void ListView::on_size(int cxd, int cyd, bool b_update_scroll)
 
         GetClientRect(get_wnd(), &rc);
         cx = RECT_CX(rc);
-        cy = RECT_CY(rc);
 
         // Reposition again due to potential vertical scrollbar changes
         if (m_wnd_header)
@@ -273,7 +269,8 @@ void ListView::process_navigation_keydown(WPARAM wp, bool alt_down, bool repeat)
         set_focus_item(target_item);
     } else if (!m_single_selection && (GetKeyState(VK_SHIFT) & KF_UP)) {
         const t_size start = m_alternate_selection ? focus : m_shift_start;
-        const pfc::bit_array_range array_select(min(start, t_size(target_item)), abs(int(start - (target_item))) + 1);
+        const pfc::bit_array_range array_select(
+            std::min(start, t_size(target_item)), abs(int(start - (target_item))) + 1);
         if (m_alternate_selection && !focus_sel)
             set_selection_state(array_select, pfc::bit_array_not(array_select), true);
         else if (m_alternate_selection)

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -198,7 +198,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             if (b_shift_down && !m_single_selection) {
                 t_size focus = get_focus_item();
                 t_size start = m_alternate_selection ? focus : m_shift_start;
-                pfc::bit_array_range br(min(start, hit_result.index), abs(t_ssize(start - hit_result.index)) + 1);
+                pfc::bit_array_range br(std::min(start, hit_result.index), abs(t_ssize(start - hit_result.index)) + 1);
                 if (m_lbutton_down_ctrl && !m_alternate_selection) {
                     set_selection_state(br, br, true);
                 } else {
@@ -358,7 +358,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                         || hit_result.category == HitTestCategory::OnItemObscuredAbove)
                     && hit_result.column != -1) {
                     if (m_tooltip_last_index != hit_result.index || m_tooltip_last_column != hit_result.column) {
-                        t_size cx = 0;
+                        int cx = 0;
                         {
                             t_size i;
                             // if (hit_result.column == 0)
@@ -493,7 +493,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                                 }
 
                                 set_selection_state(pfc::bit_array_true(),
-                                    pfc::bit_array_range(min(hit_result.index, m_selecting_start),
+                                    pfc::bit_array_range(std::min(hit_result.index, m_selecting_start),
                                         (t_size)abs(int(m_selecting_start - hit_result.index)) + 1));
                                 set_focus_item(hit_result.index);
                             }
@@ -604,7 +604,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_CHAR:
         // Values below 32, and 127, are special values (e.g. Ctrl-A and Ctrl-Backspace)
         if (!m_prevent_wm_char_processing && wp >= 32u && wp != 127u)
-            on_search_string_change(wp);
+            on_search_string_change(LOWORD(wp));
         break;
     case WM_SYSKEYDOWN: {
         if ((m_prevent_wm_char_processing = notify_on_keyboard_keydown_filter(WM_SYSKEYDOWN, wp, lp)))
@@ -737,9 +737,9 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             POINT px;
             {
                 if (from_keyboard) {
-                    t_size focus = get_focus_item();
-                    unsigned last = get_last_viewable_item();
-                    if (focus >= m_items.size() || focus < get_item_at_or_after(m_scroll_position) || focus > last) {
+                    const auto focus = gsl::narrow<int>(get_focus_item());
+                    const auto last = get_last_viewable_item();
+                    if (focus < 0 || focus < get_item_at_or_after(m_scroll_position) || focus > last) {
                         px.x = 0;
                         px.y = 0;
                     } else {

--- a/list_view/list_view_scroll.cpp
+++ b/list_view/list_view_scroll.cpp
@@ -145,8 +145,8 @@ void ListView::_update_scroll_info_horizontal()
 {
     auto rc = get_items_rect();
 
-    t_size old_scroll_position = m_horizontal_scroll_position;
-    t_size cx = get_columns_display_width() + get_total_indentation();
+    const auto old_scroll_position = m_horizontal_scroll_position;
+    const auto cx = get_columns_display_width() + get_total_indentation();
 
     SCROLLINFO scroll;
     memset(&scroll, 0, sizeof(SCROLLINFO));

--- a/list_view/list_view_search.cpp
+++ b/list_view/list_view_search.cpp
@@ -95,9 +95,9 @@ void ListView::get_search_box_rect(LPRECT rc) const
         rc->top = rc->bottom;
     }
 }
-unsigned ListView::get_search_box_height() const
+int ListView::get_search_box_height() const
 {
-    unsigned ret = 0;
+    int ret = 0;
     if (m_search_editbox) {
         RECT rc;
         get_search_box_rect(&rc);

--- a/menu.h
+++ b/menu.h
@@ -14,21 +14,27 @@ public:
         }
     }
 
-    size_t size() { return GetMenuItemCount(m_handle); }
+    uint32_t size()
+    {
+        const int size = GetMenuItemCount(m_handle);
+        THROW_LAST_ERROR_IF(size < 0);
+        return gsl::narrow<uint32_t>(size);
+    }
+
     HMENU detach()
     {
         HMENU ret = m_handle;
         m_handle = nullptr;
         return ret;
     }
-    void insert_command(size_t index, const wchar_t* text, size_t id, size_t flags = NULL)
+    void insert_command(uint32_t index, const wchar_t* text, uint32_t id, uint32_t flags = NULL)
     {
         MENUITEMINFO mii;
         memset(&mii, 0, sizeof(MENUITEMINFO));
         mii.cbSize = sizeof(MENUITEMINFO);
         mii.fMask = MIIM_ID | MIIM_STRING | MIIM_STATE | MIIM_FTYPE;
         mii.dwTypeData = const_cast<wchar_t*>(text);
-        mii.cch = wcslen(text);
+        mii.cch = gsl::narrow<UINT>(wcslen(text));
         mii.fType = MFT_STRING;
         mii.fState = MFS_ENABLED;
         if (flags & flag_radiochecked)
@@ -40,20 +46,20 @@ public:
         mii.wID = id;
         InsertMenuItem(m_handle, index, TRUE, &mii);
     }
-    void insert_submenu(size_t index, const wchar_t* text, HMENU submenu, size_t flags = NULL)
+    void insert_submenu(uint32_t index, const wchar_t* text, HMENU submenu, uint32_t flags = NULL)
     {
         MENUITEMINFO mii;
         memset(&mii, 0, sizeof(MENUITEMINFO));
         mii.cbSize = sizeof(MENUITEMINFO);
         mii.fMask = MIIM_SUBMENU | MIIM_STRING | MIIM_FTYPE;
         mii.dwTypeData = const_cast<wchar_t*>(text);
-        mii.cch = wcslen(text);
+        mii.cch = gsl::narrow<UINT>(wcslen(text));
         mii.fType = MFT_STRING;
         mii.fState = MFS_ENABLED;
         mii.hSubMenu = submenu;
         InsertMenuItem(m_handle, index, TRUE, &mii);
     }
-    void insert_separator(size_t index, size_t flags = NULL)
+    void insert_separator(uint32_t index, uint32_t flags = NULL)
     {
         MENUITEMINFO mii;
         memset(&mii, 0, sizeof(MENUITEMINFO));
@@ -62,15 +68,15 @@ public:
         mii.fType = MFT_SEPARATOR;
         InsertMenuItem(m_handle, index, TRUE, &mii);
     }
-    void append_command(const wchar_t* text, size_t id, size_t flags = NULL)
+    void append_command(const wchar_t* text, uint32_t id, uint32_t flags = NULL)
     {
         insert_command(size(), text, id, flags);
     }
-    void append_submenu(const wchar_t* text, HMENU submenu, size_t flags = NULL)
+    void append_submenu(const wchar_t* text, HMENU submenu, uint32_t flags = NULL)
     {
         insert_submenu(size(), text, submenu, flags);
     }
-    void append_separator(size_t flags = NULL) { insert_separator(size(), flags); }
+    void append_separator(uint32_t flags = NULL) { insert_separator(size(), flags); }
     size_t run(HWND wnd, const POINT& pt)
     {
         return TrackPopupMenu(m_handle, TPM_RIGHTBUTTON | TPM_NONOTIFY | TPM_RETURNCMD, pt.x, pt.y, 0, wnd, nullptr);

--- a/ole.cpp
+++ b/ole.cpp
@@ -173,7 +173,7 @@ HRESULT do_drag_drop(HWND wnd, WPARAM initialKeyState, IDataObject* pDataObject,
 
     mmh::ComPtr<IDropSource> pDropSource;
     // if (!IsVistaOrNewer())
-    pDropSource = new uih::ole::IDropSourceGeneric(wnd, pDataObject, initialKeyState, true, lpsdi);
+    pDropSource = new uih::ole::IDropSourceGeneric(wnd, pDataObject, LODWORD(initialKeyState), true, lpsdi);
     return SHDoDragDrop(wnd, pDataObject, pDropSource, dwEffect, pdwEffect);
 }
 

--- a/ole/data_object.cpp
+++ b/ole/data_object.cpp
@@ -223,7 +223,7 @@ STDMETHODIMP CDataObject::EnumFormatEtc(DWORD dwDir, LPENUMFORMATETC* ppEnum)
                     data[i] = m_data_entries[i].fe;
                 // Note: SHCreateStdEnumFmtEtc is deprecated, but still contained in current
                 // versions of Windows
-                return SHCreateStdEnumFmtEtc(count, data.get_ptr(), ppEnum);
+                return SHCreateStdEnumFmtEtc(gsl::narrow<UINT>(count), data.get_ptr(), ppEnum);
                 //*ppEnum = new CEnumFormatEtc(data.get_ptr(), count);
 
                 if (*ppEnum)

--- a/stdafx.h
+++ b/stdafx.h
@@ -30,31 +30,18 @@
 #include <gdiplus.h>
 #include <Usp10.h>
 #include <CommonControls.h>
+#include <intsafe.h>
 
 #include <wil/resource.h>
-
-// Windows SDK headers define min and max macros, which are used by gdiplus.h.
-//
-// This undefines them temporarily to avoid conflicts with the C++ standard
-// library. They are redefined at the end of this header.
-#ifdef max
-#define _UI_HELPERS_OLD_MAX_
-#undef max
-#endif
-
-#ifdef min
-#define _UI_HELPERS_OLD_MIN_
-#undef min
-#endif
 
 #include "../mmh/stdafx.h"
 
 #ifndef RECT_CX
-#define RECT_CX(rc) (rc.right - rc.left)
+#define RECT_CX(rc) ((rc).right - (rc).left)
 #endif
 
 #ifndef RECT_CY
-#define RECT_CY(rc) (rc.bottom - rc.top)
+#define RECT_CY(rc) ((rc).bottom - (rc).top)
 #endif
 
 #include "literals.h"
@@ -80,15 +67,5 @@
 
 #include "ole/data_object.h"
 #include "ole/enum_format_etc.h"
-
-#ifdef _UI_HELPERS_OLD_MAX_
-#define max(a, b) (((a) > (b)) ? (a) : (b))
-#undef _UI_HELPERS_OLD_MAX_
-#endif
-
-#ifdef _UI_HELPERS_OLD_MIN_
-#define min(a, b) (((a) < (b)) ? (a) : (b))
-#undef _UI_HELPERS_OLD_MIN_
-#endif
 
 #endif

--- a/text_drawing.h
+++ b/text_drawing.h
@@ -8,14 +8,14 @@ public:
 
     ~UniscribeTextRenderer() { cleanup(); }
 
-    UniscribeTextRenderer(HDC dc, const wchar_t* p_str, size_t p_str_len, int max_cx, bool b_clip,
+    UniscribeTextRenderer(HDC dc, const wchar_t* p_str, int p_str_len, int max_cx, bool b_clip,
         bool enable_tabs = false, int tab_origin = 0)
     {
         initialise();
         analyse(dc, p_str, p_str_len, max_cx, b_clip, enable_tabs, tab_origin);
     }
 
-    void analyse(HDC dc, const wchar_t* p_str, size_t p_str_len, int max_cx, bool b_clip, bool enable_tabs = false,
+    void analyse(HDC dc, const wchar_t* p_str, int p_str_len, int max_cx, bool b_clip, bool enable_tabs = false,
         int tab_origin = 0)
     {
         if (m_ssa) {
@@ -141,11 +141,11 @@ enum alignment {
 bool is_rect_null_or_reversed(const RECT* r);
 void get_text_size(HDC dc, const char* src, int len, SIZE& sz);
 int get_text_width(HDC dc, const char* src, int len);
-int get_text_width_colour(HDC dc, const char* src, int len, bool b_ignore_tabs = false);
-BOOL text_out_colours_ellipsis(HDC dc, const char* src, int len, int x_offset, int pos_y, const RECT* base_clip,
+int get_text_width_colour(HDC dc, const char* src, size_t len, bool b_ignore_tabs = false);
+BOOL text_out_colours_ellipsis(HDC dc, const char* src, size_t len, int x_offset, int pos_y, const RECT* base_clip,
     bool selected, bool show_ellipsis, DWORD default_color, alignment align, unsigned* p_width = nullptr,
     bool b_set_default_colours = true, int* p_position = nullptr, bool enable_tabs = false, int tab_origin = 0);
-BOOL text_out_colours_tab(HDC dc, const char* display, int display_len, int left_offset, int border,
+BOOL text_out_colours_tab(HDC dc, const char* display, size_t display_len, int left_offset, int border,
     const RECT* base_clip, bool selected, DWORD default_color, bool enable_tab_columns, bool show_ellipsis,
     alignment align, unsigned* p_width = nullptr, bool b_set_default_colours = true,
     bool b_vertical_align_centre = true, int* p_position = nullptr, int tab_origin = 0);

--- a/ui_helpers.vcxproj
+++ b/ui_helpers.vcxproj
@@ -88,7 +88,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_WIN32_WINNT=0x600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;_DEBUG;_LIB;_WIN32_WINNT=0x600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -103,7 +103,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_WIN32_WINNT=0x600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;_DEBUG;_LIB;_WIN32_WINNT=0x600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -117,7 +117,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;WIN32_WINNT=0x0600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;NDEBUG;_LIB;WIN32_WINNT=0x0600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <AssemblerOutput>
@@ -134,7 +134,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;WIN32_WINNT=0x0600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;NDEBUG;_LIB;WIN32_WINNT=0x0600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <AssemblerOutput>

--- a/win32_helpers.h
+++ b/win32_helpers.h
@@ -48,7 +48,6 @@ LRESULT list_view_insert_item_text(HWND wnd_lv, UINT item, UINT subitem, const c
     LPARAM lp = 0, int image_index = I_IMAGENONE);
 
 void tree_view_set_explorer_theme(HWND wnd, bool b_reduce_indent = false);
-void tree_view_remove_explorer_theme(HWND wnd);
 HTREEITEM tree_view_insert_item_simple(HWND wnd_tree, const char* sz_text, LPARAM data, DWORD state = TVIS_EXPANDED,
     HTREEITEM ti_parent = TVI_ROOT, HTREEITEM ti_after = TVI_LAST, bool b_image = false, UINT image = NULL,
     UINT integral_height = 1);
@@ -61,7 +60,6 @@ void tree_view_collapse_other_nodes(HWND wnd, HTREEITEM ti);
 int combo_box_add_string_data(HWND wnd, const TCHAR* str, LPARAM data);
 int combo_box_find_item_by_data(HWND wnd, t_size id);
 
-int rebar_find_item_by_id(HWND wnd, unsigned id);
 void rebar_show_all_bands(HWND wnd);
 
 BOOL shell_notify_icon(DWORD action, HWND wnd, UINT id, UINT version, UINT callbackmsg, HICON icon, const char* tip);


### PR DESCRIPTION
This corrects various integer types across the code base.

It also defines NOMINMAX (to disable the `min()` and `max()` macros).