### PR TITLE
Fix remaining 64-bit warnings

### DIFF
--- a/list_view/list_view_header.cpp
+++ b/list_view/list_view_header.cpp
@@ -172,7 +172,7 @@ bool ListView::on_wm_notify_header(LPNMHDR lpnm, LRESULT& ret)
 
                     for (size_t n = 0; n < t; n++) {
                         const char* str = get_item_text(n, realIndex);
-                        size = uih::get_text_width_colour(dc, str, strlen(str));
+                        size = get_text_width_colour(dc, str, gsl::narrow<int>(strlen(str)));
                         if (size > w)
                             w = size;
                     }

--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -385,7 +385,7 @@ bool ListView::is_item_clipped(t_size index, t_size column)
 
     pfc::string8 text = get_item_text(index, column);
     HFONT fnt_old = SelectFont(hdc, m_items_font.get());
-    int width = uih::get_text_width_colour(hdc, text, text.length());
+    int width = get_text_width_colour(hdc, text, gsl::narrow<int>(text.length()));
     SelectFont(hdc, fnt_old);
     ReleaseDC(get_wnd(), hdc);
     const auto col_width = m_columns[column].m_display_size;

--- a/text_drawing.cpp
+++ b/text_drawing.cpp
@@ -64,12 +64,12 @@ int get_text_width(HDC dc, const char* src, int len)
     return sz.cx;
 }
 
-int get_text_width_colour(HDC dc, const char* src, size_t len, bool b_ignore_tabs)
+int get_text_width_colour(HDC dc, const char* src, int len, bool b_ignore_tabs)
 {
     if (!dc)
         return 0;
-    size_t ptr = 0;
-    size_t start = 0;
+    int ptr = 0;
+    int start = 0;
     int rv = 0;
 
     while (ptr < len) {

--- a/text_drawing.h
+++ b/text_drawing.h
@@ -141,7 +141,7 @@ enum alignment {
 bool is_rect_null_or_reversed(const RECT* r);
 void get_text_size(HDC dc, const char* src, int len, SIZE& sz);
 int get_text_width(HDC dc, const char* src, int len);
-int get_text_width_colour(HDC dc, const char* src, size_t len, bool b_ignore_tabs = false);
+int get_text_width_colour(HDC dc, const char* src, int len, bool b_ignore_tabs = false);
 BOOL text_out_colours_ellipsis(HDC dc, const char* src, size_t len, int x_offset, int pos_y, const RECT* base_clip,
     bool selected, bool show_ellipsis, DWORD default_color, alignment align, unsigned* p_width = nullptr,
     bool b_set_default_colours = true, int* p_position = nullptr, bool enable_tabs = false, int tab_origin = 0);

--- a/ui_helpers.vcxproj
+++ b/ui_helpers.vcxproj
@@ -65,10 +65,20 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)$(Configuration)\$(ProjectName)\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)$(Configuration)\$(ProjectName)\</IntDir>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Configuration)\$(ProjectName)\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
@@ -141,7 +151,6 @@
       </AssemblerOutput>
       <WarningLevel>Level3</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <OmitFramePointers>false</OmitFramePointers>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>


### PR DESCRIPTION
Also tweak the project intermediate and output directories, and remove /Oy on the x64 build (as it apparently is inapplicable there).