### PR TITLE
Remove hard-coded window theme from FillWindow

### DIFF
--- a/solid_fill.h
+++ b/solid_fill.h
@@ -4,49 +4,33 @@ namespace uih {
 
 class FillWindow {
 public:
-    enum Mode {
-        mode_solid_fill,
-        mode_theme_fill,
-        mode_theme_solid_fill,
+    enum class Mode {
+        SolidFill,
+        ThemeBackgroundFill,
+        ThemeTextColourFill,
     };
 
     void set_fill_colour(COLORREF value)
     {
-        m_mode = mode_solid_fill;
+        m_mode = Mode::SolidFill;
         m_fill_colour = value;
         if (m_container_window->get_wnd())
             redraw();
     }
-    void set_fill_themed(const WCHAR* pclass, int part, int state, COLORREF fallback)
+
+    void set_fill_themed(Mode mode, const WCHAR* pclass, int part, int state, bool is_dark, COLORREF fallback)
     {
-        m_mode = mode_theme_fill;
+        m_mode = mode;
         m_theme_state = state;
         m_theme_part = part;
         m_fill_colour = fallback;
         m_theme_class = pclass;
-        if (m_theme)
-            CloseThemeData(m_theme);
-        m_theme = nullptr;
-        if (m_container_window->get_wnd()) {
-            m_theme = IsThemeActive() && IsAppThemed()
-                ? OpenThemeData(m_container_window->get_wnd(), m_theme_class.c_str())
-                : nullptr;
-            redraw();
-        }
-    }
+        m_theme.reset();
+        m_is_dark = is_dark;
 
-    void set_fill_themed_colour(const WCHAR* pclass, int index)
-    {
-        m_mode = mode_theme_solid_fill;
-        m_theme_class = pclass;
-        m_theme_colour_index = index;
-        if (m_theme)
-            CloseThemeData(m_theme);
-        m_theme = nullptr;
         if (m_container_window->get_wnd()) {
-            m_theme = IsThemeActive() && IsAppThemed()
-                ? OpenThemeData(m_container_window->get_wnd(), m_theme_class.c_str())
-                : nullptr;
+            if (IsThemeActive() && IsAppThemed())
+                m_theme.reset(OpenThemeData(m_container_window->get_wnd(), m_theme_class.c_str()));
             redraw();
         }
     }
@@ -65,81 +49,91 @@ public:
     {
         return m_container_window->create(std::forward<Ts>(vals)...);
     }
-    void destroy() { m_container_window->destroy(); }
+
+    void destroy() const { m_container_window->destroy(); }
+
     HWND get_wnd() const { return m_container_window->get_wnd(); }
 
 private:
-    void redraw()
+    void redraw() const
     {
         RedrawWindow(m_container_window->get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
-        // RedrawWindow(get_wnd(), 0, 0, RDW_INVALIDATE|RDW_ERASE);
     }
+
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     {
         switch (msg) {
-        case WM_CREATE: {
-            if (m_mode == mode_theme_fill || m_mode == mode_theme_solid_fill)
-                m_theme = IsThemeActive() && IsAppThemed() ? OpenThemeData(wnd, m_theme_class.c_str()) : nullptr;
-            SetWindowTheme(wnd, L"Explorer", nullptr);
-        } break;
-        case WM_DESTROY: {
-            if (m_theme)
-                CloseThemeData(m_theme);
-            m_theme = nullptr;
-        } break;
-        case WM_THEMECHANGED: {
-            if (m_theme)
-                CloseThemeData(m_theme);
-            m_theme = nullptr;
-            if (m_mode == mode_theme_fill || m_mode == mode_theme_solid_fill)
-                m_theme = (IsThemeActive() && IsAppThemed()) ? OpenThemeData(wnd, m_theme_class.c_str()) : nullptr;
+        case WM_CREATE:
+            if (m_mode == Mode::ThemeBackgroundFill || m_mode == Mode::ThemeTextColourFill)
+                m_theme.reset(IsThemeActive() && IsAppThemed() ? OpenThemeData(wnd, m_theme_class.c_str()) : nullptr);
+            break;
+        case WM_DESTROY:
+            m_theme.reset();
+            break;
+        case WM_THEMECHANGED:
+            m_theme.reset();
+            if (m_mode == Mode::ThemeBackgroundFill || m_mode == Mode::ThemeTextColourFill)
+                m_theme.reset(IsThemeActive() && IsAppThemed() ? OpenThemeData(wnd, m_theme_class.c_str()) : nullptr);
             redraw();
-        } break;
+            break;
         case WM_ENABLE:
             redraw();
             break;
         case WM_ERASEBKGND:
             return FALSE;
-        case WM_PAINT:
-            PAINTSTRUCT ps;
-            HDC dc = BeginPaint(wnd, &ps);
-            wil::unique_hbrush brush;
-            RECT rc;
-            GetClientRect(wnd, &rc);
+        case WM_PAINT: {
+            PAINTSTRUCT ps{};
+            const auto dc = wil::BeginPaint(wnd, &ps);
+
+            RECT client_rect{};
+            GetClientRect(wnd, &client_rect);
 
             if (!IsWindowEnabled(wnd)) {
-                FillRect(dc, &ps.rcPaint, GetSysColorBrush(COLOR_BTNFACE));
-            } else if (m_mode == mode_theme_fill && m_theme
-                && IsThemePartDefined(m_theme, m_theme_part, m_theme_state)) {
-                if (IsThemeBackgroundPartiallyTransparent(m_theme, m_theme_part, m_theme_state))
-                    DrawThemeParentBackground(wnd, dc, &rc);
-                if (FAILED(DrawThemeBackground(m_theme, dc, m_theme_part, m_theme_state, &rc, nullptr))) {
-                    brush.reset(CreateSolidBrush(m_fill_colour));
-                    FillRect(dc, &ps.rcPaint, brush.get());
-                }
-            } else if (m_mode == mode_theme_solid_fill && m_theme) {
-                COLORREF cr_fill = GetThemeSysColor(m_theme, m_theme_colour_index);
-                brush.reset(CreateSolidBrush(cr_fill));
-                FillRect(dc, &ps.rcPaint, brush.get());
-            } else {
-                brush.reset(CreateSolidBrush(m_fill_colour));
-                FillRect(dc, &ps.rcPaint, brush.get());
+                FillRect(dc.get(), &ps.rcPaint, GetSysColorBrush(COLOR_BTNFACE));
+                break;
             }
-            brush.release();
-            EndPaint(wnd, &ps);
+
+            if (m_mode == Mode::SolidFill || !m_theme
+                || !IsThemePartDefined(m_theme.get(), m_theme_part, m_theme_state)) {
+                const wil::unique_hbrush brush(CreateSolidBrush(m_fill_colour));
+                FillRect(dc.get(), &ps.rcPaint, brush.get());
+            } else if (m_mode == Mode::ThemeBackgroundFill) {
+                if (IsThemeBackgroundPartiallyTransparent(m_theme.get(), m_theme_part, m_theme_state))
+                    DrawThemeParentBackground(wnd, dc.get(), &client_rect);
+
+                RECT background_rect = client_rect;
+
+                if (m_is_dark) {
+                    InflateRect(&background_rect, 1, 1);
+                }
+
+                if (FAILED(DrawThemeBackground(
+                        m_theme.get(), dc.get(), m_theme_part, m_theme_state, &background_rect, &client_rect))) {
+                    const wil::unique_hbrush brush(CreateSolidBrush(m_fill_colour));
+                    FillRect(dc.get(), &ps.rcPaint, brush.get());
+                }
+            } else if (m_mode == Mode::ThemeTextColourFill) {
+                COLORREF fill_colour = m_fill_colour;
+                GetThemeColor(m_theme.get(), m_theme_part, m_theme_state, TMT_TEXTCOLOR, &fill_colour);
+                const wil::unique_hbrush brush(CreateSolidBrush(fill_colour));
+                FillRect(dc.get(), &ps.rcPaint, brush.get());
+            }
+
             return 0;
+        }
         }
         return DefWindowProc(wnd, msg, wp, lp);
     };
 
-    Mode m_mode{mode_solid_fill};
+    Mode m_mode{Mode::SolidFill};
     std::wstring m_theme_class;
     COLORREF m_fill_colour = NULL;
-    HTHEME m_theme = nullptr;
+    wil::unique_htheme m_theme;
     int m_theme_part = NULL;
     int m_theme_state = NULL;
     int m_theme_colour_index = NULL;
     std::unique_ptr<uih::ContainerWindow> m_container_window;
+    bool m_is_dark{};
 };
 
 class TranslucentFillWindow {


### PR DESCRIPTION
This stops FillWindow setting a window theme (so that the calling code can specify a window theme in the theme class), and makes other changes related to supporting dark mode in Colours and fonts preferences in Columns UI.

It also generally tidies up the class and fixes a GDI object leak inadvertently added in #63.