### PR TITLE
Use actual pointer size for trackbar tooltip offset

### DIFF
--- a/stdafx.h
+++ b/stdafx.h
@@ -16,6 +16,7 @@
 #include <ppl.h>
 
 #include <gsl/gsl>
+#include <range/v3/all.hpp>
 
 // Included before windows.h, because pfc.h includes winsock2.h
 #include "../pfc/pfc.h"

--- a/trackbar_base.cpp
+++ b/trackbar_base.cpp
@@ -6,18 +6,13 @@ BOOL TrackbarBase::create_tooltip(const TCHAR* text, POINT pt)
 {
     destroy_tooltip();
 
-    DLLVERSIONINFO2 dvi;
-    bool b_comctl_6 = SUCCEEDED(uih::get_comctl32_version(dvi)) && dvi.info1.dwMajorVersion >= 6;
-
-    m_wnd_tooltip = CreateWindowEx(WS_EX_TOPMOST | (b_comctl_6 ? WS_EX_TRANSPARENT : 0), TOOLTIPS_CLASS, nullptr,
+    m_wnd_tooltip = CreateWindowEx(WS_EX_TOPMOST | WS_EX_TRANSPARENT, TOOLTIPS_CLASS, nullptr,
         WS_POPUP | TTS_NOPREFIX | TTS_ALWAYSTIP, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, get_wnd(),
         nullptr, mmh::get_current_instance(), nullptr);
 
     SetWindowPos(m_wnd_tooltip, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
 
-    TOOLINFO ti;
-
-    memset(&ti, 0, sizeof(ti));
+    TOOLINFO ti{};
 
     ti.cbSize = TTTOOLINFO_V1_SIZE;
     ti.uFlags = TTF_SUBCLASS | TTF_TRANSPARENT | TTF_TRACK | TTF_ABSOLUTE;
@@ -27,8 +22,10 @@ BOOL TrackbarBase::create_tooltip(const TCHAR* text, POINT pt)
 
     uih::tooltip_add_tool(m_wnd_tooltip, &ti);
 
-    SendMessage(m_wnd_tooltip, TTM_TRACKPOSITION, 0, MAKELONG(pt.x, pt.y + 21));
-    SendMessage(m_wnd_tooltip, TTM_TRACKACTIVATE, TRUE, (LPARAM)&ti);
+    m_cursor_height = get_pointer_height();
+
+    SendMessage(m_wnd_tooltip, TTM_TRACKPOSITION, 0, MAKELONG(pt.x, pt.y + m_cursor_height));
+    SendMessage(m_wnd_tooltip, TTM_TRACKACTIVATE, TRUE, reinterpret_cast<LPARAM>(&ti));
 
     return TRUE;
 }
@@ -46,7 +43,7 @@ BOOL TrackbarBase::update_tooltip(POINT pt, const TCHAR* text)
     if (!m_wnd_tooltip)
         return FALSE;
 
-    SendMessage(m_wnd_tooltip, TTM_TRACKPOSITION, 0, MAKELONG(pt.x, pt.y + 21));
+    SendMessage(m_wnd_tooltip, TTM_TRACKPOSITION, 0, MAKELONG(pt.x, pt.y + m_cursor_height));
 
     TOOLINFO ti;
     memset(&ti, 0, sizeof(ti));

--- a/trackbar_base.h
+++ b/trackbar_base.h
@@ -405,6 +405,8 @@ private:
      */
     unsigned m_range{0};
 
+    int m_cursor_height{};
+
     /**
      * Hot state of the thumb.
      */

--- a/win32_helpers.h
+++ b/win32_helpers.h
@@ -30,7 +30,6 @@ inline KeyboardLParam& GetKeyboardLParam(LPARAM& lp)
 
 bool are_keyboard_cues_enabled();
 
-HRESULT get_comctl32_version(DLLVERSIONINFO2& p_dvi);
 BOOL set_process_dpi_aware();
 
 // This is cached as system-DPI changes take effect at next log on.
@@ -39,6 +38,8 @@ BOOL set_process_dpi_aware();
 // See https://msdn.microsoft.com/en-gb/library/windows/desktop/dn469266%28v=vs.85%29.aspx
 SIZE get_system_dpi_cached();
 int scale_dpi_value(int value, unsigned original_dpi = USER_DEFAULT_SCREEN_DPI);
+
+int get_pointer_height();
 
 void list_view_set_explorer_theme(HWND wnd);
 int list_view_insert_column_text(HWND wnd_lv, int index, const TCHAR* text, int cx);


### PR DESCRIPTION
Previously, the tooltip offset from the pointer position was a hard-coded 21 pixels. This corrects that so the offset is based on the actual size of the pointer.