### PR TITLE
Only override list view header text colour in dark mode

### DIFF
--- a/list_view/list_view_header.cpp
+++ b/list_view/list_view_header.cpp
@@ -126,7 +126,10 @@ bool ListView::on_wm_notify_header(LPNMHDR lpnm, LRESULT& ret)
 {
     switch (lpnm->code) {
     case NM_CUSTOMDRAW: {
-        LPNMCUSTOMDRAW lpcd = (LPNMCUSTOMDRAW)lpnm;
+        if (!m_header_theme)
+            return false;
+
+        const auto lpcd = reinterpret_cast<LPNMCUSTOMDRAW>(lpnm);
         switch (lpcd->dwDrawStage) {
         case CDDS_PREPAINT:
             ret = CDRF_NOTIFYITEMDRAW;
@@ -147,14 +150,14 @@ bool ListView::on_wm_notify_header(LPNMHDR lpnm, LRESULT& ret)
     }
     case HDN_BEGINTRACKA:
     case HDN_BEGINTRACKW: {
-        auto lpnmh = (LPNMHEADER)lpnm;
+        const auto lpnmh = reinterpret_cast<LPNMHEADERW>(lpnm);
         if (m_autosize && (!get_show_group_info_area() || lpnmh->iItem)) {
             ret = TRUE;
             return true;
         }
     } break;
     case HDN_DIVIDERDBLCLICK: {
-        auto lpnmh = (LPNMHEADER)lpnm;
+        const auto lpnmh = reinterpret_cast<LPNMHEADERW>(lpnm);
         if (!m_autosize) {
             if (lpnmh->iItem != -1 && (!m_have_indent_column || lpnmh->iItem)) {
                 t_size realIndex = lpnmh->iItem;

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -572,8 +572,8 @@ void ListView::reopen_themes()
             OpenThemeData(theme_wnd, m_use_dark_mode ? L"DarkMode_ItemsView::ListView" : L"ItemsView::ListView"));
         if (!m_use_dark_mode)
             m_items_view_theme.reset(OpenThemeData(theme_wnd, L"ItemsView"));
-        m_header_theme.reset(
-            OpenThemeData(theme_wnd, m_use_dark_mode ? L"DarkMode_ItemsView::Header" : L"ItemsView::Header"));
+        if (m_use_dark_mode)
+            m_header_theme.reset(OpenThemeData(theme_wnd, L"DarkMode_ItemsView::Header"));
         m_dd_theme.reset(OpenThemeData(get_wnd(), VSCLASS_DRAGDROP));
     }
 }


### PR DESCRIPTION
This disables the overriding of the list view header text colour when dark mode is disabled.

This is due to it looking odd on e.g. Windows 7 (without the rest of the control's appearance matching Windows Explorer).