### PR TITLE
Fix erasing behaviour of paint_subclassed_window_with_buffering()

### DIFF
--- a/gdi.cpp
+++ b/gdi.cpp
@@ -8,8 +8,8 @@ void paint_subclassed_window_with_buffering(HWND wnd, WNDPROC window_proc)
     const auto paint_dc = wil::BeginPaint(wnd, &ps);
     const auto buffered_dc = BufferedDC(paint_dc.get(), ps.rcPaint);
 
-    const auto print_client_flags = PRF_CLIENT | (ps.fErase ? PRF_ERASEBKGND : 0);
-    CallWindowProc(window_proc, wnd, WM_PRINTCLIENT, reinterpret_cast<WPARAM>(buffered_dc.get()), print_client_flags);
+    CallWindowProc(window_proc, wnd, WM_ERASEBKGND, reinterpret_cast<WPARAM>(buffered_dc.get()), 0);
+    CallWindowProc(window_proc, wnd, WM_PRINTCLIENT, reinterpret_cast<WPARAM>(buffered_dc.get()), PRF_CLIENT);
 }
 
 void draw_rect_outline(HDC dc, const RECT& rc, COLORREF colour, int width)


### PR DESCRIPTION
This makes `paint_subclassed_window_with_buffering()` always erase the background, and do so using `WM_ERASEBKGND` instead of  `WM_PRINTCLIENT`.

This is because the memory bitmap will always start off empty (and hence erasing is always required), and as support for the `PRF_ERASEBKGND` flag of `WM_PRINTCLIENT` is very patchy.