### PR TITLE
Add relaxed single selection mode to list view

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -114,6 +114,14 @@ protected:
     };
 
 public:
+    enum class SelectionMode {
+        Multiple,
+        /** Single selection, right-click changes selection, can deselect all items */
+        SingleRelaxed,
+        /** Single selection, right-click doesn't change the selection, can't deselect all items */
+        SingleStrict
+    };
+
     ListView(std::unique_ptr<uih::lv::RendererBase> renderer = std::make_unique<uih::lv::DefaultRenderer>())
         : m_renderer{std::move(renderer)}
     {
@@ -177,7 +185,7 @@ public:
 
     void set_variable_height_items(bool b_variable_height_items) { m_variable_height_items = b_variable_height_items; }
 
-    void set_single_selection(bool b_single_selection) { m_single_selection = b_single_selection; }
+    void set_selection_mode(SelectionMode mode) { m_selection_mode = mode; }
 
     void set_alternate_selection_model(bool b_alternate_selection) { m_alternate_selection = b_alternate_selection; }
 
@@ -859,7 +867,7 @@ private:
     EdgeStyle m_edge_style{edge_grey};
     bool m_sizing{false};
 
-    bool m_single_selection{false};
+    SelectionMode m_selection_mode{SelectionMode::Multiple};
     bool m_alternate_selection{false};
     bool m_allow_header_rearrange{false};
 

--- a/list_view/list_view_keyboard.cpp
+++ b/list_view/list_view_keyboard.cpp
@@ -61,7 +61,7 @@ bool ListView::on_wm_keydown(WPARAM wp, LPARAM lp)
     case VK_F3:
         return notify_on_keyboard_keydown_search();
     case 'A':
-        if (process_ctrl_char_shortcuts && !m_single_selection) {
+        if (process_ctrl_char_shortcuts && m_selection_mode == SelectionMode::Multiple) {
             set_selection_state(pfc::bit_array_true(), pfc::bit_array_true());
             return true;
         }

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -267,7 +267,7 @@ void ListView::process_navigation_keydown(WPARAM wp, bool alt_down, bool repeat)
         move_selection(target_item - focus);
     } else if ((GetKeyState(VK_CONTROL) & KF_UP)) {
         set_focus_item(target_item);
-    } else if (!m_single_selection && (GetKeyState(VK_SHIFT) & KF_UP)) {
+    } else if (m_selection_mode == SelectionMode::Multiple && (GetKeyState(VK_SHIFT) & KF_UP)) {
         const t_size start = m_alternate_selection ? focus : m_shift_start;
         const pfc::bit_array_range array_select(
             std::min(start, t_size(target_item)), abs(int(start - (target_item))) + 1);


### PR DESCRIPTION
This adds a relaxed version of the single selection mode to the list view, that still allows the selection to be changed when right-clicking and when clicking in empty space.