### PR TITLE
Delay list view scroll bar redraw after items transaction

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -281,9 +281,9 @@ public:
     };
 
     void hit_test_ex(POINT pt_client, HitTestResult& result);
-    void update_scroll_info(bool b_vertical = true, bool b_horizontal = true);
-    void _update_scroll_info_vertical();
-    void _update_scroll_info_horizontal();
+    void update_scroll_info(bool b_vertical = true, bool b_horizontal = true, bool redraw = true);
+    void _update_scroll_info_vertical(bool redraw = true);
+    void _update_scroll_info_horizontal(bool redraw = true);
     ItemVisibility get_item_visibility(t_size index);
     bool is_partially_visible(t_size index);
     bool is_fully_visible(t_size index);
@@ -320,7 +320,7 @@ public:
     void get_search_box_rect(LPRECT rc) const;
     int get_search_box_height() const;
 
-    void invalidate_all(bool b_children = false);
+    void invalidate_all(bool b_children = false, bool non_client = false);
     void invalidate_items(t_size index, t_size count);
 
     void invalidate_items(const pfc::bit_array& mask);

--- a/list_view/list_view_items.cpp
+++ b/list_view/list_view_items.cpp
@@ -21,8 +21,8 @@ ListView::ItemTransaction::~ItemTransaction() noexcept
         return;
 
     m_list_view.__calculate_item_positions(*m_start_index);
-    m_list_view.update_scroll_info();
-    m_list_view.invalidate_all();
+    m_list_view.update_scroll_info(true, true, false);
+    m_list_view.invalidate_all(false, true);
 }
 
 void ListView::ItemTransaction::insert_items(size_t index_start, size_t count, const InsertItem* items)

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -306,9 +306,10 @@ void ListView::on_focus_change(t_size index_prev, t_size index_new)
     if (index_new < count)
         invalidate_items(index_new, 1);
 }
-void ListView::invalidate_all(bool b_children)
+void ListView::invalidate_all(bool b_children, bool non_client)
 {
-    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | (b_children ? RDW_ALLCHILDREN : 0));
+    auto flags = RDW_INVALIDATE | (b_children ? RDW_ALLCHILDREN : 0) | (non_client ? RDW_FRAME : 0);
+    RedrawWindow(get_wnd(), nullptr, nullptr, flags);
 }
 
 void ListView::update_items(t_size index, t_size count)

--- a/list_view/list_view_scroll.cpp
+++ b/list_view/list_view_scroll.cpp
@@ -116,7 +116,7 @@ void ListView::scroll_from_scroll_bar(short scroll_bar_command, bool b_horizonta
     scroll(pos, b_horizontal);
 }
 
-void ListView::_update_scroll_info_vertical()
+void ListView::_update_scroll_info_vertical(bool redraw)
 {
     const auto rc = get_items_rect();
 
@@ -132,7 +132,7 @@ void ListView::_update_scroll_info_vertical()
     scroll.nPos = m_scroll_position;
     bool b_old_show = (GetWindowLongPtr(get_wnd(), GWL_STYLE) & WS_VSCROLL) != 0;
     ;
-    m_scroll_position = SetScrollInfo(get_wnd(), SB_VERT, &scroll, true);
+    m_scroll_position = SetScrollInfo(get_wnd(), SB_VERT, &scroll, redraw);
     GetScrollInfo(get_wnd(), SB_VERT, &scroll);
     bool b_show = (GetWindowLongPtr(get_wnd(), GWL_STYLE) & WS_VSCROLL) != 0; // scroll.nPage < (UINT)scroll.nMax;
     // if (b_old_show != b_show)
@@ -141,7 +141,7 @@ void ListView::_update_scroll_info_vertical()
         invalidate_all();
 }
 
-void ListView::_update_scroll_info_horizontal()
+void ListView::_update_scroll_info_horizontal(bool redraw)
 {
     auto rc = get_items_rect();
 
@@ -157,7 +157,7 @@ void ListView::_update_scroll_info_horizontal()
     scroll.nPage = m_autosize ? 0 : RECT_CX(rc);
     bool b_old_show = (GetWindowLongPtr(get_wnd(), GWL_STYLE) & WS_HSCROLL) != 0;
     ;
-    m_horizontal_scroll_position = SetScrollInfo(get_wnd(), SB_HORZ, &scroll, true);
+    m_horizontal_scroll_position = SetScrollInfo(get_wnd(), SB_HORZ, &scroll, redraw);
     GetScrollInfo(get_wnd(), SB_HORZ, &scroll);
     bool b_show = (GetWindowLongPtr(get_wnd(), GWL_STYLE) & WS_HSCROLL) != 0; // scroll.nPage < (UINT)scroll.nMax;
     // if (b_old_show != b_show)
@@ -175,19 +175,19 @@ void ListView::_update_scroll_info_horizontal()
         scroll.cbSize = sizeof(SCROLLINFO);
         scroll.fMask = SIF_PAGE;
         scroll.nPage = RECT_CY(rc);
-        m_scroll_position = SetScrollInfo(get_wnd(), SB_VERT, &scroll, true);
+        m_scroll_position = SetScrollInfo(get_wnd(), SB_VERT, &scroll, redraw);
     }
 }
 
-void ListView::update_scroll_info(bool b_vertical, bool b_horizontal)
+void ListView::update_scroll_info(bool b_vertical, bool b_horizontal, bool redraw)
 {
     // god this is a bit complicated when showing h scrollbar causes need for v scrollbar (and vv)
 
     if (b_vertical) {
-        _update_scroll_info_vertical();
+        _update_scroll_info_vertical(redraw);
     }
     if (b_horizontal) {
-        _update_scroll_info_horizontal();
+        _update_scroll_info_horizontal(redraw);
     }
 }
 


### PR DESCRIPTION
This makes the list view delay redrawing of scroll bars following a transaction to insert and/or remove multiple items.