### PR TITLE
Add list view search contexts

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -135,6 +135,25 @@ protected:
     private:
     };
 
+    class ListViewSearchContextBase {
+    public:
+        virtual ~ListViewSearchContextBase() = default;
+
+        virtual const char* get_item_text(size_t index) = 0;
+
+    protected:
+    };
+
+    class DefaultListViewSearchContext : public ListViewSearchContextBase {
+    public:
+        explicit DefaultListViewSearchContext(ListView* list_view) : m_list_view(list_view) {}
+
+        const char* get_item_text(size_t index) override { return m_list_view->get_item_text(index, 0); }
+
+    private:
+        ListView* m_list_view{};
+    };
+
 public:
     enum class SelectionMode {
         Multiple,
@@ -599,6 +618,11 @@ protected:
     virtual Item* storage_create_item() { return new Item; }
 
     virtual Group* storage_create_group() { return new Group; }
+
+    virtual std::unique_ptr<ListViewSearchContextBase> create_search_context()
+    {
+        return std::make_unique<DefaultListViewSearchContext>(this);
+    }
 
     Item* get_item(t_size index) { return m_items[index].get_ptr(); }
 

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -535,11 +535,13 @@ void ListView::on_search_string_change(WCHAR c)
         else
             focus++;
     }
+    const auto context = create_search_context();
+
     for (i = 0; i < count; i++) {
         t_size j = (i + focus) % count;
         t_item_ptr item = m_items[j];
 
-        const char* p_compare = get_item_text(j, 0);
+        const char* p_compare = context->get_item_text(j);
         pfc::string8 compare_noccodes;
 
         if (strchr(p_compare, 3)) {


### PR DESCRIPTION
This adds the concept of search contexts to the list view. These provide the text of items when typing directly in the list view to jump to matching items.

A custom search context can be used in cases where the default context has poor performance (i.e. virtualised lists where getting the text for an individual item is expensive).