### PR TITLE
Add edit control enhancer and window subclassing helper

### DIFF
--- a/list_view/list_view_inline_edit.cpp
+++ b/list_view/list_view_inline_edit.cpp
@@ -114,13 +114,6 @@ LRESULT ListView::on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM l
         break;
     case WM_GETDLGCODE:
         return CallWindowProc(m_proc_inline_edit, wnd, msg, wp, lp) | DLGC_WANTALLKEYS;
-    case WM_CHAR:
-        // Note: The Edit control on Windows 10 1809 and newer also processes Ctrl-A in WM_CHAR
-        if (!(HIWORD(lp) & KF_REPEAT) && wp == 1 && (GetKeyState(VK_CONTROL) & KF_UP)) {
-            Edit_SetSel(wnd, 0, -1);
-            return 0;
-        }
-        break;
     case WM_KEYDOWN:
         switch (wp) {
         case VK_TAB: {
@@ -340,6 +333,8 @@ void ListView::create_inline_edit(const pfc::list_base_const_t<t_size>& indices,
         SetWindowLongPtr(m_wnd_inline_edit, GWLP_USERDATA, reinterpret_cast<LPARAM>(this));
         m_proc_inline_edit = reinterpret_cast<WNDPROC>(
             SetWindowLongPtr(m_wnd_inline_edit, GWLP_WNDPROC, reinterpret_cast<LPARAM>(g_on_inline_edit_message)));
+
+        enhance_edit_control(m_wnd_inline_edit);
 
         SetWindowPos(m_wnd_inline_edit, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 

--- a/stdafx.h
+++ b/stdafx.h
@@ -65,6 +65,7 @@
 #include "drag_image.h"
 #include "info_box.h"
 #include "menu.h"
+#include "window_subclasser.h"
 
 #include "ole/data_object.h"
 #include "ole/enum_format_etc.h"

--- a/ui_helpers.vcxproj
+++ b/ui_helpers.vcxproj
@@ -182,6 +182,7 @@
     <ClInclude Include="trackbar.h" />
     <ClInclude Include="trackbar_base.h" />
     <ClInclude Include="win32_helpers.h" />
+    <ClInclude Include="window_subclasser.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="container_window.cpp" />
@@ -299,6 +300,7 @@
     <ClCompile Include="trackbar.cpp" />
     <ClCompile Include="trackbar_base.cpp" />
     <ClCompile Include="win32_helpers.cpp" />
+    <ClCompile Include="window_subclasser.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="LICENCE" />

--- a/ui_helpers.vcxproj
+++ b/ui_helpers.vcxproj
@@ -41,11 +41,13 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -99,14 +101,10 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;NOMINMAX;_DEBUG;_LIB;_WIN32_WINNT=0x600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>false</MinimalRebuild>
-      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
@@ -115,14 +113,10 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;NOMINMAX;_DEBUG;_LIB;_WIN32_WINNT=0x600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>false</MinimalRebuild>
-      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>

--- a/ui_helpers.vcxproj.filters
+++ b/ui_helpers.vcxproj.filters
@@ -46,6 +46,7 @@
     <ClInclude Include="trackbar_base.h">
       <Filter>Trackbar</Filter>
     </ClInclude>
+    <ClInclude Include="window_subclasser.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="message_hook.cpp" />
@@ -114,6 +115,7 @@
     <ClCompile Include="trackbar_base.cpp">
       <Filter>Trackbar</Filter>
     </ClCompile>
+    <ClCompile Include="window_subclasser.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" />

--- a/win32_helpers.h
+++ b/win32_helpers.h
@@ -149,4 +149,8 @@ public:
 
     IntegerAndDpi(TInteger _value = NULL, uint32_t _dpi = USER_DEFAULT_SCREEN_DPI) : value(_value), dpi(_dpi){};
 };
+
+void enhance_edit_control(HWND wnd);
+void enhance_edit_control(HWND wnd, int id);
+
 } // namespace uih

--- a/window_subclasser.cpp
+++ b/window_subclasser.cpp
@@ -1,0 +1,37 @@
+#include "stdafx.h"
+
+namespace uih {
+
+namespace {
+
+struct WindowState {
+    WNDPROC wnd_proc{};
+    std::function<std::optional<LRESULT>(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> message_handler;
+};
+
+std::unordered_map<HWND, WindowState> state_map;
+
+LRESULT handle_subclassed_window_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+{
+    const auto& state = state_map.at(wnd);
+    const auto wnd_proc = state.wnd_proc;
+
+    if (const auto result = state.message_handler(wnd, msg, wp, lp))
+        return *result;
+
+    if (msg == WM_NCDESTROY)
+        state_map.erase(wnd);
+
+    return CallWindowProcW(wnd_proc, wnd, msg, wp, lp);
+}
+
+} // namespace
+
+void subclass_window(
+    HWND wnd, std::function<std::optional<LRESULT>(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> message_handler)
+{
+    const auto wnd_proc = SubclassWindow(wnd, handle_subclassed_window_message);
+    state_map[wnd] = WindowState{wnd_proc, std::move(message_handler)};
+}
+
+} // namespace uih

--- a/window_subclasser.h
+++ b/window_subclasser.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace uih {
+
+void subclass_window(
+    HWND wnd, std::function<std::optional<LRESULT>(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> message_handler);
+
+}


### PR DESCRIPTION
This:

- adds a `subclass_window()` function that lets you subclass a window using a lambda function or similar
- adds an `enhance_edit_control()` function that adds some enhancements to edit controls. Currently, this is handling of Ctrl+Backspace to delete the previous word, and Ctrl+A to select all text
- `updates uih::ListView` to use `enhance_edit_control()` during inline editing
- tidies up the debug project configurations