### PR TITLE
Add save and restore scroll position functionality to list view

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8

--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -4,6 +4,16 @@
 
 namespace uih {
 
+namespace lv {
+
+struct SavedScrollPosition {
+    int32_t previous_item_index{};
+    int32_t next_item_index{};
+    double proportional_position{};
+};
+
+} // namespace lv
+
 class ListView {
 public:
     static constexpr short IDC_HEADER = 1001;
@@ -180,6 +190,9 @@ public:
     alignment get_column_alignment(size_t index);
     size_t get_column_count();
 
+    lv::SavedScrollPosition save_scroll_position() const;
+    void restore_scroll_position(const lv::SavedScrollPosition& position);
+
     void _set_scroll_position(int val) { m_scroll_position = val; }
 
     [[nodiscard]] int _get_scroll_position() const { return m_scroll_position; }
@@ -223,7 +236,8 @@ public:
     void update_column_sizes();
 
     ItemTransaction start_transaction();
-    void insert_items(size_t index_start, size_t count, const InsertItem* items);
+    void insert_items(size_t index_start, size_t count, const InsertItem* items,
+        const std::optional<lv::SavedScrollPosition>& saved_scroll_position = std::nullopt);
 
     template <class TItems>
     void replace_items(size_t index_start, const TItems& items)
@@ -236,7 +250,8 @@ public:
     void remove_all_items();
 
     void hit_test_ex(POINT pt_client, HitTestResult& result);
-    void update_scroll_info(bool b_vertical = true, bool b_horizontal = true, bool redraw = true);
+    void update_scroll_info(bool b_vertical = true, bool b_horizontal = true, bool redraw = true,
+        std::optional<int> new_vertical_position = std::nullopt);
     ItemVisibility get_item_visibility(size_t index);
     bool is_partially_visible(size_t index);
     bool is_fully_visible(size_t index);
@@ -653,6 +668,8 @@ protected:
     void focus_search_box();
 
 private:
+    virtual void on_first_show();
+
     virtual void notify_on_focus_item_change(size_t new_index) {}
 
     virtual void notify_on_initialisation() {} // set settings here
@@ -730,7 +747,7 @@ private:
 
     virtual void notify_exit_inline_edit() {}
 
-    void update_vertical_scroll_info(bool redraw = true);
+    void update_vertical_scroll_info(bool redraw = true, std::optional<int> new_vertical_position = std::nullopt);
     void update_horizontal_scroll_info(bool redraw = true);
 
     [[nodiscard]] unsigned calculate_scroll_timer_speed() const;

--- a/list_view/list_view_items.cpp
+++ b/list_view/list_view_items.cpp
@@ -42,12 +42,17 @@ ListView::ItemTransaction ListView::start_transaction()
     return {*this};
 }
 
-void ListView::insert_items(size_t index_start, size_t count, const InsertItem* items)
+void ListView::insert_items(size_t index_start, size_t count, const InsertItem* items,
+    const std::optional<lv::SavedScrollPosition>& saved_scroll_position)
 {
     insert_items_in_internal_state(index_start, count, items);
     calculate_item_positions(index_start);
-    // profiler(pvt_render);
-    update_scroll_info();
+
+    if (saved_scroll_position)
+        restore_scroll_position(*saved_scroll_position);
+    else
+        update_scroll_info();
+
     RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
 }
 

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -2,33 +2,17 @@
 
 namespace uih {
 
+void ListView::on_first_show()
+{
+    if (const size_t focus = get_focus_item(); focus != std::numeric_limits<size_t>::max())
+        ensure_visible(focus);
+}
+
 void ListView::refresh_item_positions()
 {
-    // Work out where the scroll position is proportionally in the item at the
-    // scroll position, or between the previous and next items if the scroll
-    // position is between items
-    const auto previous_item_index = get_item_at_or_before(m_scroll_position);
-    const auto next_item_index = get_item_at_or_after(m_scroll_position);
-    const auto next_item_bottom = get_item_position_bottom(next_item_index);
-    const auto previous_item_top = get_item_position(previous_item_index);
-    // If next_item_bottom == previous_item_bottom == 0, there are probably no items
-    const auto proportional_position = next_item_bottom != previous_item_top
-        ? static_cast<double>(m_scroll_position - previous_item_top)
-            / static_cast<double>(next_item_bottom - previous_item_top)
-        : 0.0;
-
+    const auto position = save_scroll_position();
     calculate_item_positions();
-    update_scroll_info();
-
-    // Restore the scroll position
-    const auto new_next_item_bottom = get_item_position_bottom(next_item_index);
-    const auto new_previous_item_top = get_item_position(previous_item_index);
-    const auto new_position = proportional_position * static_cast<double>(new_next_item_bottom - new_previous_item_top)
-        + new_previous_item_top;
-    const auto new_position_rounded = gsl::narrow<int>(std::lround(new_position));
-    scroll(new_position_rounded, false, true);
-
-    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
+    restore_scroll_position(position);
 }
 
 bool ListView::copy_selected_items_as_text(size_t default_single_item_column)

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -593,9 +593,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         return DefWindowProc(wnd, msg, wp, lp) | DLGC_WANTARROWS;
     case WM_SHOWWINDOW:
         if (wp == TRUE && lp == 0 && !m_shown) {
-            size_t focus = get_focus_item();
-            if (focus != pfc_infinite)
-                ensure_visible(focus);
+            on_first_show();
             m_shown = true;
         }
         break;


### PR DESCRIPTION
This adds functionality to the list view to save and restore vertical scroll positions in a way resistant to configuration changes (font size change etc).