### PR TITLE
Add dark mode support to trackbar tooltips

### DIFF
--- a/trackbar_base.cpp
+++ b/trackbar_base.cpp
@@ -10,6 +10,8 @@ BOOL TrackbarBase::create_tooltip(const TCHAR* text, POINT pt)
         WS_POPUP | TTS_NOPREFIX | TTS_ALWAYSTIP, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, get_wnd(),
         nullptr, mmh::get_current_instance(), nullptr);
 
+    set_tooltip_theme();
+
     SetWindowPos(m_wnd_tooltip, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
 
     TOOLINFO ti{};
@@ -20,7 +22,7 @@ BOOL TrackbarBase::create_tooltip(const TCHAR* text, POINT pt)
     ti.hinst = mmh::get_current_instance();
     ti.lpszText = const_cast<TCHAR*>(text);
 
-    uih::tooltip_add_tool(m_wnd_tooltip, &ti);
+    tooltip_add_tool(m_wnd_tooltip, &ti);
 
     m_cursor_height = get_pointer_height();
 
@@ -28,6 +30,13 @@ BOOL TrackbarBase::create_tooltip(const TCHAR* text, POINT pt)
     SendMessage(m_wnd_tooltip, TTM_TRACKACTIVATE, TRUE, reinterpret_cast<LPARAM>(&ti));
 
     return TRUE;
+}
+
+void TrackbarBase::set_tooltip_theme() const
+{
+    if (m_wnd_tooltip) {
+        SetWindowTheme(m_wnd_tooltip, m_are_tooltips_dark ? L"DarkMode_Explorer" : nullptr, nullptr);
+    }
 }
 
 void TrackbarBase::destroy_tooltip()
@@ -69,6 +78,12 @@ void TrackbarBase::set_show_tooltips(bool val)
     m_show_tooltips = val;
     if (!val)
         destroy_tooltip();
+}
+
+void TrackbarBase::set_are_tooltips_dark(bool are_tooltips_dark)
+{
+    m_are_tooltips_dark = are_tooltips_dark;
+    set_tooltip_theme();
 }
 
 void TrackbarBase::set_position_internal(unsigned pos)

--- a/trackbar_base.h
+++ b/trackbar_base.h
@@ -297,6 +297,11 @@ public:
     void set_show_tooltips(bool b_show);
 
     /**
+     * \brief Set whether tooltips are dark themed.
+     */
+    void set_are_tooltips_dark(bool are_tooltips_dark);
+
+    /**
      * Default constructor for TrackbarBase class
      */
     TrackbarBase()
@@ -362,7 +367,7 @@ private:
 
     /**
      * Used internally by the track bar.\n
-     * Used to calulate the position at a given point.
+     * Used to calculate the position at a given point.
      *
      * \param [in]    pt            Client co-ordinate to test.
      * \return                      Position at pt specified.
@@ -377,6 +382,11 @@ private:
      * \param [in]    pt            Position of the mouse pointer, in screen co-ordinates.
      */
     BOOL create_tooltip(const TCHAR* text, POINT pt);
+
+    /**
+     * \brief Set the window theme of the tooltip.
+     */
+    void set_tooltip_theme() const;
 
     /**
      * Used internally by the track bar.\n
@@ -442,6 +452,8 @@ private:
      * Show tooltips state.
      */
     bool m_show_tooltips{false};
+
+    bool m_are_tooltips_dark{};
 
     /**
      * Window focus was obtained from.

--- a/ui_helpers.vcxproj
+++ b/ui_helpers.vcxproj
@@ -109,6 +109,7 @@
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -121,6 +122,7 @@
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -135,6 +137,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
@@ -150,6 +153,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>


### PR DESCRIPTION
This adds dark mode support to tooltips in the trackbar control.

It also updates the compiler settings to treat warnings as errors.