### PR TITLE
Fix Clang warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalOptions Condition="'$(PlatformToolset)'=='ClangCL'">%(AdditionalOptions) -Wno-delete-non-abstract-non-virtual-dtor</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/container_window.cpp
+++ b/container_window.cpp
@@ -130,8 +130,7 @@ void ContainerWindow::register_class()
 
 void ContainerWindow::deregister_class()
 {
-    const auto unregistered = UnregisterClass(m_config.class_name, mmh::get_current_instance());
-    assert(unregistered);
+    assert(UnregisterClass(m_config.class_name, mmh::get_current_instance()));
 }
 
 } // namespace uih

--- a/gdi.cpp
+++ b/gdi.cpp
@@ -14,12 +14,10 @@ void paint_subclassed_window_with_buffering(HWND wnd, WNDPROC window_proc)
 
 void draw_rect_outline(HDC dc, const RECT& rc, COLORREF colour, int width)
 {
-    wil::unique_hpen pen(CreatePen(PS_SOLID | PS_INSIDEFRAME, width, colour));
-    HBRUSH old_brush = SelectBrush(dc, GetStockObject(NULL_BRUSH));
-    HPEN old_pen = SelectPen(dc, pen.get());
+    const wil::unique_hpen pen(CreatePen(PS_SOLID | PS_INSIDEFRAME, width, colour));
+    auto _selected_brush = wil::SelectObject(dc, GetStockObject(NULL_BRUSH));
+    auto _selected_pen = wil::SelectObject(dc, pen.get());
     Rectangle(dc, rc.left, rc.top, rc.right, rc.bottom);
-    SelectBrush(dc, old_brush);
-    SelectPen(dc, pen.get());
 }
 
 } // namespace uih

--- a/info_box.h
+++ b/info_box.h
@@ -234,7 +234,7 @@ private:
             }
             break;
         case WM_CLOSE:
-            auto container_window{move(m_container_window)};
+            auto container_window{std::move(m_container_window)};
             container_window->destroy();
             return 0;
         }

--- a/list_view/list_view_columns.cpp
+++ b/list_view/list_view_columns.cpp
@@ -1,4 +1,4 @@
-#include "../stdafx.h"
+#include "stdafx.h"
 
 namespace uih {
 

--- a/list_view/list_view_drag_image.cpp
+++ b/list_view/list_view_drag_image.cpp
@@ -1,4 +1,4 @@
-#include "../stdafx.h"
+#include "stdafx.h"
 
 namespace uih {
 

--- a/list_view/list_view_header.cpp
+++ b/list_view/list_view_header.cpp
@@ -1,4 +1,4 @@
-#include "../stdafx.h"
+#include "stdafx.h"
 #include "list_view.h"
 
 namespace uih {

--- a/list_view/list_view_hittest.cpp
+++ b/list_view/list_view_hittest.cpp
@@ -1,4 +1,4 @@
-#include "../stdafx.h"
+#include "stdafx.h"
 
 namespace uih {
 

--- a/list_view/list_view_inline_edit.cpp
+++ b/list_view/list_view_inline_edit.cpp
@@ -1,4 +1,4 @@
-#include "../stdafx.h"
+#include "stdafx.h"
 
 namespace uih {
 

--- a/list_view/list_view_item_state.cpp
+++ b/list_view/list_view_item_state.cpp
@@ -1,4 +1,4 @@
-#include "../stdafx.h"
+#include "stdafx.h"
 
 namespace uih {
 

--- a/list_view/list_view_items.cpp
+++ b/list_view/list_view_items.cpp
@@ -1,4 +1,4 @@
-#include "../stdafx.h"
+#include "stdafx.h"
 
 #define GROUP_STRING_COMPARE strcmp
 
@@ -444,7 +444,6 @@ void ListView::remove_item_in_internal_state(size_t index)
     m_items.erase(m_items.begin() + index);
 
     if (index < m_items.size()) {
-        int item_height = m_item_height;
         size_t j;
         if (index) {
             size_t i;

--- a/list_view/list_view_keyboard.cpp
+++ b/list_view/list_view_keyboard.cpp
@@ -1,4 +1,4 @@
-#include "../stdafx.h"
+#include "stdafx.h"
 
 namespace uih {
 

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -1,4 +1,4 @@
-#include "../stdafx.h"
+#include "stdafx.h"
 
 namespace uih {
 

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -1,4 +1,4 @@
-#include "../stdafx.h"
+#include "stdafx.h"
 
 namespace uih {
 
@@ -246,10 +246,9 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     }
         return 0;
     case WM_LBUTTONUP: {
-        POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
         if (m_selecting_move && !m_selecting_moved && !m_lbutton_down_ctrl) {
             if (m_selecting_start < m_items.size()) {
-                if (!m_inline_edit_prevent && 1 && get_item_selected(m_selecting_start) && true /*m_prev_sel*/) {
+                if (!m_inline_edit_prevent && get_item_selected(m_selecting_start)) {
                     {
                         exit_inline_edit();
                         pfc::list_t<size_t> indices;

--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -1,4 +1,4 @@
-#include "../stdafx.h"
+#include "stdafx.h"
 
 namespace uih {
 
@@ -69,7 +69,6 @@ void ListView::render_items(HDC dc, const RECT& rc_update, int cx)
 
         size_t j;
         size_t countj = m_items[i]->m_groups.size();
-        size_t counter = 0;
         for (j = 0; j < countj; j++) {
             if (!i || m_items[i]->m_groups[j] != m_items[i - 1]->m_groups[j]) {
                 t_group_ptr p_group = m_items[i]->m_groups[j];
@@ -85,8 +84,6 @@ void ListView::render_items(HDC dc, const RECT& rc_update, int cx)
                 }
                 m_renderer->render_group(
                     context, i, j, p_group->m_text.get_ptr(), cx_space * level_spacing_size, j, rc);
-
-                counter++;
             }
         }
 
@@ -253,7 +250,7 @@ void lv::DefaultRenderer::render_item(RendererContext context, size_t index, std
 {
     int theme_state = NULL;
     if (b_selected) {
-        if (b_highlight || b_focused && b_window_focused)
+        if (b_highlight || (b_focused && b_window_focused))
             theme_state = LISS_HOTSELECTED;
         else if (b_window_focused)
             theme_state = LISS_SELECTED;

--- a/list_view/list_view_scroll.cpp
+++ b/list_view/list_view_scroll.cpp
@@ -1,4 +1,4 @@
-#include "../stdafx.h"
+#include "stdafx.h"
 
 namespace uih {
 

--- a/list_view/list_view_search.cpp
+++ b/list_view/list_view_search.cpp
@@ -1,4 +1,4 @@
-#include "../stdafx.h"
+#include "stdafx.h"
 
 namespace uih {
 

--- a/list_view/list_view_tooltip.cpp
+++ b/list_view/list_view_tooltip.cpp
@@ -1,4 +1,4 @@
-#include "../stdafx.h"
+#include "stdafx.h"
 
 namespace uih {
 

--- a/ole/data_object.cpp
+++ b/ole/data_object.cpp
@@ -6,7 +6,7 @@
  * The licence terms for the relevant Windows SDK are contained in windows-sdk-6.1-licence.html.
  */
 
-#include "../stdafx.h"
+#include "stdafx.h"
 
 /**************************************************************************
 THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF
@@ -148,16 +148,15 @@ HRESULT CDataObject::_FindFormatEtc(LPFORMATETC pFE, size_t& index, bool b_check
         return DV_E_DVTARGETDEVICE;
 
     index = 0;
-    bool b_found;
-    if (b_found = m_data_entries.bsearch_t(t_data_entry::g_compare_formatetc_value, pFE, index)) {
+
+    if (m_data_entries.bsearch_t(t_data_entry::g_compare_formatetc_value, pFE, index)) {
         if (!b_checkTymed || (m_data_entries[index].fe.tymed & pFE->tymed)) // why & ?
         {
             return S_OK;
         }
         return DV_E_TYMED;
     }
-    // console::formatter() << "_FindFormatEtc" << ": " << (int)pFE->cfFormat << " " << (int)pFE->dwAspect << " " <<
-    // (int)pFE->lindex << " " << b_found << " " << index;
+
     return DV_E_FORMATETC;
 }
 

--- a/ole/enum_format_etc.cpp
+++ b/ole/enum_format_etc.cpp
@@ -1,4 +1,4 @@
-#include "../stdafx.h"
+#include "stdafx.h"
 
 /**
  * This code is based on:

--- a/text_drawing.cpp
+++ b/text_drawing.cpp
@@ -326,8 +326,6 @@ BOOL text_out_colours_tab(HDC dc, const char* display, size_t display_len, int l
 
     auto ptr = display_len;
     int tab_ptr = 0;
-    int written = 0;
-    int clip_x = clip.right;
     RECT t_clip = clip;
 
     do {

--- a/ui_helpers.vcxproj
+++ b/ui_helpers.vcxproj
@@ -52,18 +52,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
@@ -71,18 +59,22 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</OutDir>
     <IntDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</IntDir>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ProjectDir)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</OutDir>
     <IntDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</IntDir>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ProjectDir)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</OutDir>
     <IntDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</IntDir>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ProjectDir)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</OutDir>
     <IntDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</IntDir>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ProjectDir)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
@@ -188,104 +180,24 @@
     <ClCompile Include="dpi.cpp" />
     <ClCompile Include="drag_image.cpp" />
     <ClCompile Include="gdi.cpp" />
-    <ClCompile Include="list_view\list_view_columns.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <ClCompile Include="list_view\list_view_drag_image.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <ClCompile Include="list_view\list_view_header.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <ClCompile Include="list_view\list_view_hittest.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <ClCompile Include="list_view\list_view_inline_edit.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <ClCompile Include="list_view\list_view_item_state.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <ClCompile Include="list_view\list_view_items.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <ClCompile Include="list_view\list_view_keyboard.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <ClCompile Include="list_view\list_view_misc.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <ClCompile Include="list_view\list_view_msgproc.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <ClCompile Include="list_view\list_view_renderer.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <ClCompile Include="list_view\list_view_scroll.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <ClCompile Include="list_view\list_view_search.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <ClCompile Include="list_view\list_view_tooltip.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
+    <ClCompile Include="list_view\list_view_columns.cpp" />
+    <ClCompile Include="list_view\list_view_drag_image.cpp" />
+    <ClCompile Include="list_view\list_view_header.cpp" />
+    <ClCompile Include="list_view\list_view_hittest.cpp" />
+    <ClCompile Include="list_view\list_view_inline_edit.cpp" />
+    <ClCompile Include="list_view\list_view_item_state.cpp" />
+    <ClCompile Include="list_view\list_view_items.cpp" />
+    <ClCompile Include="list_view\list_view_keyboard.cpp" />
+    <ClCompile Include="list_view\list_view_misc.cpp" />
+    <ClCompile Include="list_view\list_view_msgproc.cpp" />
+    <ClCompile Include="list_view\list_view_renderer.cpp" />
+    <ClCompile Include="list_view\list_view_scroll.cpp" />
+    <ClCompile Include="list_view\list_view_search.cpp" />
+    <ClCompile Include="list_view\list_view_tooltip.cpp" />
     <ClCompile Include="literals.cpp" />
     <ClCompile Include="ole.cpp" />
-    <ClCompile Include="ole\data_object.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <ClCompile Include="ole\enum_format_etc.cpp">
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
-    </ClCompile>
+    <ClCompile Include="ole\data_object.cpp" />
+    <ClCompile Include="ole\enum_format_etc.cpp" />
     <ClCompile Include="message_hook.cpp" />
     <ClCompile Include="solid_fill.cpp" />
     <ClCompile Include="stdafx.cpp">

--- a/win32_helpers.cpp
+++ b/win32_helpers.cpp
@@ -107,7 +107,7 @@ size_t tree_view_get_child_index(HWND wnd_tv, HTREEITEM ti)
 {
     HTREEITEM item = ti;
     unsigned n = 0;
-    while (item = TreeView_GetPrevSibling(wnd_tv, item))
+    while ((item = TreeView_GetPrevSibling(wnd_tv, item)))
         n++;
     return n;
 }

--- a/window_subclasser.cpp
+++ b/window_subclasser.cpp
@@ -11,7 +11,7 @@ struct WindowState {
 
 std::unordered_map<HWND, WindowState> state_map;
 
-LRESULT handle_subclassed_window_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT __stdcall handle_subclassed_window_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     const auto& state = state_map.at(wnd);
     const auto wnd_proc = state.wnd_proc;


### PR DESCRIPTION
This fixes all Clang warnings except for `no-delete-non-abstract-non-virtual-dtor`, as `no-delete-non-abstract-non-virtual-dtor` is commonly encountered when using the foobar2000 SDK.