### PR TITLE
Reinstate Clang no-delete-non-abstract-non-virtual-dtor warning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalOptions Condition="'$(PlatformToolset)'=='ClangCL'">%(AdditionalOptions) -Wno-delete-non-abstract-non-virtual-dtor</AdditionalOptions>
+      <AdditionalOptions Condition="'$(PlatformToolset)'=='ClangCL'">%(AdditionalOptions) -Wno-error=delete-non-abstract-non-virtual-dtor</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
The Clang warning `no-delete-non-abstract-non-virtual-dtor` was previously disabled when treat warnings as errors was enabled. Rather than disable that warning completely, this downgrades it back to a warning.