### PR TITLE
Fix ContainerWindow::deregister_class() in release builds

### DIFF
--- a/container_window.cpp
+++ b/container_window.cpp
@@ -130,7 +130,8 @@ void ContainerWindow::register_class()
 
 void ContainerWindow::deregister_class()
 {
-    assert(UnregisterClass(m_config.class_name, mmh::get_current_instance()));
+    [[maybe_unused]] const auto unregistered = UnregisterClass(m_config.class_name, mmh::get_current_instance());
+    assert(unregistered);
 }
 
 } // namespace uih


### PR DESCRIPTION
https://github.com/reupen/columns_ui/issues/767

An incorrect use of `assert()` was causing the `UnregisterClass()` call to be omitted in release builds. Caused by #113.

