### PR TITLE
Deactivate list view inline editing in more scenarios

### DIFF
--- a/event_token.h
+++ b/event_token.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace uih {
+
+struct EventToken {
+    virtual ~EventToken() = default;
+};
+
+} // namespace uih

--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -340,7 +340,11 @@ public:
         return ret;
     }
 
-    void clear_all_items() { m_items.clear(); }
+    void clear_all_items()
+    {
+        m_items.clear();
+        PostMessage(get_wnd(), MSG_KILL_INLINE_EDIT, 0, 0);
+    }
 
     [[nodiscard]] int get_item_group_header_total_height(size_t index) const
     {

--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -805,17 +805,19 @@ private:
     wil::unique_hfont m_header_font;
     wil::unique_hfont m_group_font;
 
+    bool m_use_dark_mode{};
     wil::unique_htheme m_list_view_theme;
     wil::unique_htheme m_items_view_theme;
     wil::unique_htheme m_header_theme;
     wil::unique_htheme m_dd_theme;
 
-    HWND m_wnd_header{nullptr};
-    HWND m_wnd_inline_edit{nullptr};
-    WNDPROC m_proc_inline_edit{nullptr};
-    WNDPROC m_proc_original_inline_edit{nullptr};
+    HWND m_wnd_header{};
+
+    HWND m_wnd_inline_edit{};
+    WNDPROC m_proc_inline_edit{};
+    WNDPROC m_proc_original_inline_edit{};
+    std::unique_ptr<EventToken> m_inline_edit_mouse_hook;
     pfc::string8 m_inline_edit_initial_text;
-    bool m_use_dark_mode{};
     bool m_inline_edit_save{false};
     bool m_inline_edit_saving{false};
     bool m_timer_inline_edit{false};

--- a/list_view/list_view_inline_edit.cpp
+++ b/list_view/list_view_inline_edit.cpp
@@ -353,7 +353,7 @@ void ListView::create_inline_edit(const pfc::list_base_const_t<size_t>& indices,
                   const auto lpmhs = reinterpret_cast<LPMOUSEHOOKSTRUCT>(lp);
 
                   if (code == HC_ACTION && is_click && m_wnd_inline_edit && lpmhs->hwnd != m_wnd_inline_edit)
-                      PostMessage(get_wnd(), MSG_KILL_INLINE_EDIT, 0, 0);
+                      PostMessage(get_wnd(), MSG_KILL_INLINE_EDIT, TRUE, 0);
 
                   return false;
               });

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -742,7 +742,13 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         };
         break;
     case MSG_KILL_INLINE_EDIT:
+        m_inline_edit_prevent_kill = true;
+
+        if (wp == TRUE)
+            save_inline_edit();
+
         exit_inline_edit();
+        m_inline_edit_prevent_kill = false;
         return 0;
     case WM_CONTEXTMENU: {
         POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};

--- a/message_hook.h
+++ b/message_hook.h
@@ -22,4 +22,8 @@ public:
 
 void register_message_hook(MessageHookType p_type, MessageHook* p_hook);
 void deregister_message_hook(MessageHookType p_type, MessageHook* p_hook);
+
+using MessageHookCallback = std::function<bool(int code, WPARAM wp, LPARAM lp)>;
+std::unique_ptr<EventToken> register_message_hook(MessageHookType type, MessageHookCallback callback);
+
 } // namespace uih

--- a/stdafx.h
+++ b/stdafx.h
@@ -46,6 +46,7 @@
 #endif
 
 #include "literals.h"
+#include "event_token.h"
 
 #include "handle.h"
 #include "win32_helpers.h"

--- a/ui_helpers.vcxproj
+++ b/ui_helpers.vcxproj
@@ -154,6 +154,7 @@
     <ClInclude Include="dialog.h" />
     <ClInclude Include="dpi.h" />
     <ClInclude Include="drag_image.h" />
+    <ClInclude Include="event_token.h" />
     <ClInclude Include="handle.h" />
     <ClInclude Include="list_view\list_view.h" />
     <ClInclude Include="list_view\list_view_renderer.h" />

--- a/ui_helpers.vcxproj.filters
+++ b/ui_helpers.vcxproj.filters
@@ -47,6 +47,7 @@
       <Filter>Trackbar</Filter>
     </ClInclude>
     <ClInclude Include="window_subclasser.h" />
+    <ClInclude Include="event_token.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="message_hook.cpp" />


### PR DESCRIPTION
This makes inline editing in the list view control deactivate in more scenarios:

- when clicking outside the edit box (without the focus changing)
- when all items in the list view are removed

The first case results in a save, consistent with File Explorer.