### PR TITLE
Fix rendering of list view focus rectangle with high contrast themes

### DIFF
--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -299,6 +299,7 @@ void lv::DefaultRenderer::render_item(RendererContext context, size_t index, std
                                             : context.colours.m_background))
                 .get());
     }
+
     RECT rc_subitem = rc;
 
     for (size_t column_index{0}; column_index < sub_items.size(); ++column_index) {
@@ -323,6 +324,19 @@ void lv::DefaultRenderer::render_focus_rect(RendererContext context, bool should
             context.items_view_theme, theming::items_view_part_focus_rect, theming::items_view_state_focus_rect_normal);
 
     if (use_themed_rect) {
+        auto _ = gsl::finally([&context, result = SaveDC(context.dc)] {
+            if (result)
+                RestoreDC(context.dc, -1);
+        });
+
+        RECT content_rc{};
+        const auto hr = GetThemeBackgroundContentRect(context.items_view_theme, context.dc,
+            theming::items_view_part_focus_rect, theming::items_view_state_focus_rect_normal, &rc, &content_rc);
+
+        if (SUCCEEDED(hr)) {
+            ExcludeClipRect(context.dc, content_rc.left, content_rc.top, content_rc.right, content_rc.bottom);
+        }
+
         DrawThemeBackground(context.items_view_theme, context.dc, theming::items_view_part_focus_rect,
             theming::items_view_state_focus_rect_normal, &rc, nullptr);
 


### PR DESCRIPTION
https://github.com/reupen/columns_ui/issues/837

This works around a problem where the focus rectangle obscured the rest of the list view item when high contrast mode is active on recent versions of Windows.

(Unfortunately, a proper solution wasn't found, so this merely works around the problem.)