### PR TITLE
Improve list view high contrast theme support

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -934,6 +934,7 @@ private:
     bool m_search_box_hot{false};
     // HTHEME m_search_box_theme;
     // gdi_object_t<HBRUSH>::ptr_t m_search_box_hot_brush, m_search_box_nofocus_brush;
+    bool m_is_high_contrast_active{};
 
     bool m_group_level_indentation_enabled{true};
     std::optional<int> m_group_level_indentation_amount;

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -563,6 +563,8 @@ void ListView::reopen_themes()
             m_header_theme.reset(OpenThemeData(theme_wnd, L"DarkMode_ItemsView::Header"));
         m_dd_theme.reset(OpenThemeData(get_wnd(), VSCLASS_DRAGDROP));
     }
+
+    m_is_high_contrast_active = is_high_contrast_active();
 }
 
 void ListView::close_themes()

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -87,6 +87,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         break;*/
     case WM_THEMECHANGED:
         reopen_themes();
+        RedrawWindow(wnd, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE);
         break;
     case WM_TIMECHANGE:
         notify_on_time_change();

--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -42,8 +42,8 @@ int ListView::get_default_indentation_step(HDC dc) const
 void ListView::render_items(HDC dc, const RECT& rc_update, int cx)
 {
     ColourData colours = render_get_colour_data();
-    const lv::RendererContext context
-        = {colours, m_use_dark_mode, get_wnd(), dc, m_list_view_theme.get(), m_items_view_theme.get()};
+    const lv::RendererContext context = {colours, m_use_dark_mode, m_is_high_contrast_active, get_wnd(), dc,
+        m_list_view_theme.get(), m_items_view_theme.get()};
 
     // OffsetWindowOrgEx(dc, m_horizontal_scroll_position, 0, NULL);
     size_t highlight_index = get_highlight_item();

--- a/list_view/list_view_renderer.h
+++ b/list_view/list_view_renderer.h
@@ -25,6 +25,7 @@ struct RendererSubItem {
 struct RendererContext {
     ColourData colours{};
     bool m_use_dark_mode{};
+    bool m_is_high_contrast_active{};
     HWND wnd{};
     HDC dc{};
     HTHEME list_view_theme{};

--- a/win32_helpers.cpp
+++ b/win32_helpers.cpp
@@ -27,6 +27,14 @@ bool are_keyboard_cues_enabled()
     return a != 0;
 }
 
+bool is_high_contrast_active()
+{
+    HIGHCONTRAST hc{};
+    hc.cbSize = sizeof(HIGHCONTRAST);
+    SystemParametersInfo(SPI_GETHIGHCONTRAST, sizeof(hc), &hc, 0);
+    return (hc.dwFlags & HCF_HIGHCONTRASTON) != 0;
+}
+
 void tree_view_set_explorer_theme(HWND wnd, bool b_reduce_indent)
 {
     if (mmh::is_windows_vista_or_newer()) {

--- a/win32_helpers.h
+++ b/win32_helpers.h
@@ -29,6 +29,7 @@ inline KeyboardLParam& GetKeyboardLParam(LPARAM& lp)
 }
 
 bool are_keyboard_cues_enabled();
+bool is_high_contrast_active();
 
 BOOL set_process_dpi_aware();
 


### PR DESCRIPTION
This:

- adds the current high contrast mode status to the list view renderer context
- redraws the list view after a theme change to fix glitches after enabling a high contrast theme