### PR TITLE
Improve DirectWrite text format creation

### DIFF
--- a/direct_write.h
+++ b/direct_write.h
@@ -58,7 +58,8 @@ class Context {
 public:
     Context();
 
-    TextFormat create_text_format(const LOGFONT& log_font);
+    TextFormat create_text_format(const LOGFONT& log_font, float font_size);
+    std::optional<TextFormat> create_text_format_with_fallback(const LOGFONT& log_font, float font_size) noexcept;
 
 private:
     wil::com_ptr_t<IDWriteFactory> m_factory;


### PR DESCRIPTION
This improves handling of font sizes in `uih::direct_write::Context::create_text_format()`, and adds another method that fallback to the system icon font if the creation of the text format fails.