### PR TITLE
Migrate list view to DirectWrite

### DIFF
--- a/direct_write_text_out.h
+++ b/direct_write_text_out.h
@@ -2,8 +2,8 @@
 
 namespace uih::direct_write {
 
-void text_out_columns_and_colours(const TextFormat& text_format, HDC dc, std::string_view text, int x_offset,
-    int border, const RECT& rect, bool selected, COLORREF default_colour, bool enable_colour_codes,
-    bool enable_tab_columns, alignment align = uih::ALIGN_LEFT);
+int text_out_columns_and_colours(const TextFormat& text_format, HDC dc, std::string_view text, int x_offset, int border,
+    const RECT& rect, bool selected, COLORREF default_colour, bool enable_colour_codes, bool enable_tab_columns,
+    alignment align = uih::ALIGN_LEFT, bool enable_ellipses = true);
 
 } // namespace uih::direct_write

--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -227,9 +227,9 @@ public:
         m_dark_edit_background_colour = background_colour;
     }
     void set_vertical_item_padding(int val);
-    void set_font(const LPLOGFONT lplf);
-    void set_group_font(const LPLOGFONT lplf);
-    void set_header_font(const LPLOGFONT lplf);
+    void set_font(const LOGFONT& log_font, std::optional<float> font_size = std::nullopt);
+    void set_group_font(const LOGFONT& log_font, std::optional<float> font_size = std::nullopt);
+    void set_header_font(const LOGFONT& log_font);
     void set_sorting_enabled(bool b_val);
     void set_show_sort_indicators(bool b_val);
     void set_edge_style(uint32_t b_val);
@@ -700,6 +700,11 @@ protected:
     void focus_search_box();
 
 private:
+    struct FontConfig {
+        LOGFONT log_font{};
+        std::optional<float> size;
+    };
+
     virtual void on_first_show();
 
     virtual void notify_on_focus_item_change(size_t new_index) {}
@@ -821,6 +826,9 @@ private:
     void reopen_themes();
     void close_themes();
 
+    void refresh_items_font();
+    void refresh_group_font();
+
     void create_header();
     void destroy_header();
     void set_header_window_theme() const;
@@ -831,11 +839,10 @@ private:
     void destroy_tooltip();
     void set_tooltip_window_theme() const;
     bool is_item_clipped(size_t index, size_t column);
-    int get_text_width(const char* text, size_t length);
+    int get_tooltip_text_width(const char* text, size_t length) const;
 
     wil::unique_hfont m_items_font;
     wil::unique_hfont m_header_font;
-    wil::unique_hfont m_group_font;
 
     bool m_use_dark_mode{};
     wil::unique_htheme m_list_view_theme;
@@ -862,12 +869,12 @@ private:
     COLORREF m_dark_edit_background_colour{};
     COLORREF m_dark_edit_text_colour{RGB(255, 255, 255)};
 
-    LOGFONT m_lf_items{0};
-    LOGFONT m_lf_header{0};
-    LOGFONT m_lf_group_header{0};
-    bool m_lf_items_valid{false};
-    bool m_lf_header_valid{false};
-    bool m_lf_group_header_valid{false};
+    std::optional<FontConfig> m_items_font_config{};
+    std::optional<FontConfig> m_group_font_config{};
+    std::optional<LOGFONT> m_header_log_font{};
+    direct_write::Context::Ptr m_direct_write_context;
+    std::optional<direct_write::TextFormat> m_items_text_format;
+    std::optional<direct_write::TextFormat> m_group_text_format;
 
     bool m_selecting{false};
     bool m_selecting_move{false};

--- a/list_view/list_view_drag_image.cpp
+++ b/list_view/list_view_drag_image.cpp
@@ -12,9 +12,9 @@ bool ListView::render_drag_image(LPSHDRAGIMAGE lpsdi)
 
     auto icon = get_drag_image_icon();
 
-    LOGFONT lf;
-    if (m_lf_items_valid)
-        lf = m_lf_items;
+    LOGFONT lf{};
+    if (m_items_font_config)
+        lf = m_items_font_config->log_font;
     else
         GetObject(m_items_font.get(), sizeof(lf), &lf);
 

--- a/list_view/list_view_header.cpp
+++ b/list_view/list_view_header.cpp
@@ -17,7 +17,7 @@ void ListView::create_header()
     // if (m_show_header)
     {
         if (!m_wnd_header) {
-            m_header_font.reset(m_lf_header_valid ? CreateFontIndirect(&m_lf_header) : uih::create_icon_font());
+            m_header_font.reset(m_header_log_font ? CreateFontIndirect(&*m_header_log_font) : create_icon_font());
             m_wnd_header = CreateWindowEx(0, WC_HEADER, _T("NGLVH"),
                 WS_CHILD | (0) | /*(m_autosize ? 0x0800  : NULL) |*/ HDS_HOTTRACK
                     | (m_allow_header_rearrange ? HDS_DRAGDROP : NULL) | HDS_HORZ | HDS_FULLDRAG

--- a/list_view/list_view_renderer.h
+++ b/list_view/list_view_renderer.h
@@ -30,6 +30,8 @@ struct RendererContext {
     HDC dc{};
     HTHEME list_view_theme{};
     HTHEME items_view_theme{};
+    std::optional<direct_write::TextFormat> m_item_text_format;
+    std::optional<direct_write::TextFormat> m_group_text_format;
 };
 
 class RendererBase {

--- a/stdafx.h
+++ b/stdafx.h
@@ -66,6 +66,7 @@
 #include "gdi.h"
 #include "uniscribe.h"
 #include "uniscribe_text_out.h"
+#include "text_out_helpers.h"
 #include "direct_write.h"
 #include "direct_write_text_out.h"
 #include "list_view/list_view.h"

--- a/text_out_helpers.cpp
+++ b/text_out_helpers.cpp
@@ -1,0 +1,35 @@
+#include "stdafx.h"
+
+using namespace std::string_view_literals;
+
+namespace uih {
+
+std::string remove_colour_codes(std::string_view text)
+{
+    std::string stripped_text;
+    size_t offset{};
+
+    while (true) {
+        const size_t index = text.find("\3"sv, offset);
+
+        const auto fragment_length = index == std::string_view::npos ? std::string_view::npos : index - offset;
+        const auto fragment = text.substr(offset, fragment_length);
+
+        if (!fragment.empty())
+            stripped_text.append(fragment);
+
+        if (index == std::string_view::npos)
+            break;
+
+        offset = text.find("\3"sv, index + 1);
+
+        if (offset == std::string_view::npos)
+            break;
+
+        ++offset;
+    }
+
+    return stripped_text;
+}
+
+} // namespace uih

--- a/text_out_helpers.h
+++ b/text_out_helpers.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace uih {
+
+std::string remove_colour_codes(std::string_view text);
+
+}

--- a/ui_helpers.vcxproj
+++ b/ui_helpers.vcxproj
@@ -169,6 +169,7 @@
     <ClInclude Include="info_box.h" />
     <ClInclude Include="solid_fill.h" />
     <ClInclude Include="stdafx.h" />
+    <ClInclude Include="text_out_helpers.h" />
     <ClInclude Include="uniscribe_text_out.h" />
     <ClInclude Include="direct_write_text_out.h" />
     <ClInclude Include="theming.h" />
@@ -211,6 +212,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="text_out_helpers.cpp" />
     <ClCompile Include="uniscribe_text_out.cpp" />
     <ClCompile Include="direct_write_text_out.cpp" />
     <ClCompile Include="trackbar.cpp" />

--- a/ui_helpers.vcxproj.filters
+++ b/ui_helpers.vcxproj.filters
@@ -51,6 +51,7 @@
     <ClInclude Include="direct_write.h" />
     <ClInclude Include="uniscribe.h" />
     <ClInclude Include="direct_write_text_out.h" />
+    <ClInclude Include="text_out_helpers.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="message_hook.cpp" />
@@ -122,6 +123,7 @@
     <ClCompile Include="window_subclasser.cpp" />
     <ClCompile Include="direct_write.cpp" />
     <ClCompile Include="direct_write_text_out.cpp" />
+    <ClCompile Include="text_out_helpers.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" />


### PR DESCRIPTION
This makes the list view use DirectWrite for text rendering rather than Uniscribe. (Text rendering in tooltips and inline edit controls remain unchanged.)

This also includes some fixes and improvements to positioning when rendering text using DirectWrite.