### PR TITLE
Use DirectWrite to render list view tooltips

### DIFF
--- a/direct_write.h
+++ b/direct_write.h
@@ -18,7 +18,7 @@ public:
     }
 
     DWRITE_TEXT_METRICS get_metrics() const;
-    void render(HDC dc, RECT rect, COLORREF default_colour) const;
+    void render(HDC dc, RECT rect, COLORREF default_colour, float x_origin_offset = 0.0f) const;
     void set_colour(COLORREF colour, DWRITE_TEXT_RANGE text_range) const;
 
 private:
@@ -26,6 +26,14 @@ private:
     wil::com_ptr_t<IDWriteFactory> m_factory;
     wil::com_ptr_t<IDWriteGdiInterop> m_gdi_interop;
     wil::com_ptr_t<IDWriteTextLayout> m_text_layout;
+};
+
+struct TextPosition {
+    int left{};
+    float left_remainder_dip{};
+    int top{};
+    int width{};
+    int height{};
 };
 
 class TextFormat {
@@ -44,8 +52,9 @@ public:
     void disable_trimming_sign() const;
 
     [[nodiscard]] int get_minimum_height() const;
+    [[nodiscard]] TextPosition measure_text_position(
+        std::wstring_view text, int height, float max_width = 65536.0f) const;
     [[nodiscard]] int measure_text_width(std::wstring_view text) const;
-    [[nodiscard]] int measure_text_width(std::string_view text) const;
     [[nodiscard]] TextLayout create_text_layout(std::wstring_view text, float max_width, float max_height) const;
 
 private:

--- a/direct_write_text_out.cpp
+++ b/direct_write_text_out.cpp
@@ -72,12 +72,7 @@ int text_out_colours(const TextFormat& text_format, HDC dc, std::string_view tex
 
     std::wstring_view render_text = enable_colour_codes ? text_without_colours : utf16_text_view;
 
-    if (align == ALIGN_CENTRE)
-        text_format.set_alignment(DWRITE_TEXT_ALIGNMENT_CENTER);
-    else if (align == ALIGN_RIGHT)
-        text_format.set_alignment(DWRITE_TEXT_ALIGNMENT_TRAILING);
-    else
-        text_format.set_alignment(DWRITE_TEXT_ALIGNMENT_LEADING);
+    text_format.set_alignment(get_text_alignment(align));
 
     try {
         const auto scaling_factor = TextLayout::s_default_scaling_factor();
@@ -105,6 +100,18 @@ int text_out_colours(const TextFormat& text_format, HDC dc, std::string_view tex
 }
 
 } // namespace
+
+DWRITE_TEXT_ALIGNMENT get_text_alignment(alignment alignment_)
+{
+    switch (alignment_) {
+    case ALIGN_CENTRE:
+        return DWRITE_TEXT_ALIGNMENT_CENTER;
+    case ALIGN_RIGHT:
+        return DWRITE_TEXT_ALIGNMENT_TRAILING;
+    default:
+        return DWRITE_TEXT_ALIGNMENT_LEADING;
+    }
+}
 
 int text_out_columns_and_colours(const TextFormat& text_format, HDC dc, std::string_view text, int x_offset, int border,
     const RECT& rect, bool selected, COLORREF default_colour, bool enable_colour_codes, bool enable_tab_columns,

--- a/direct_write_text_out.h
+++ b/direct_write_text_out.h
@@ -2,6 +2,8 @@
 
 namespace uih::direct_write {
 
+DWRITE_TEXT_ALIGNMENT get_text_alignment(alignment alignment_);
+
 int text_out_columns_and_colours(const TextFormat& text_format, HDC dc, std::string_view text, int x_offset, int border,
     const RECT& rect, bool selected, COLORREF default_colour, bool enable_colour_codes, bool enable_tab_columns,
     alignment align = uih::ALIGN_LEFT, bool enable_ellipses = true);

--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -793,7 +793,7 @@ private:
     void destroy_timer_search();
 
     void process_navigation_keydown(WPARAM wp, bool alt_down, bool repeat);
-    bool on_wm_notify_header(LPNMHDR lpnm, LRESULT& ret);
+    std::optional<LRESULT> on_wm_notify_header(LPNMHDR lpnm);
     bool on_wm_keydown(WPARAM wp, LPARAM lp);
 
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
@@ -838,8 +838,10 @@ private:
     void create_tooltip(/*size_t index, size_t column, */ const char* str);
     void destroy_tooltip();
     void set_tooltip_window_theme() const;
+    void calculate_tooltip_position(size_t item_index, size_t column_index, std::string_view text);
+    std::optional<LRESULT> on_wm_notify_tooltip(LPNMHDR lpnm);
+    void render_tooltip_text(HWND wnd, HDC dc, COLORREF colour) const;
     bool is_item_clipped(size_t index, size_t column);
-    int get_tooltip_text_width(const char* text, size_t length) const;
 
     wil::unique_hfont m_items_font;
     wil::unique_hfont m_header_font;
@@ -849,6 +851,7 @@ private:
     wil::unique_htheme m_items_view_theme;
     wil::unique_htheme m_header_theme;
     wil::unique_htheme m_dd_theme;
+    wil::unique_htheme m_tooltip_theme;
 
     HWND m_wnd_header{};
 
@@ -916,7 +919,9 @@ private:
     bool m_show_tooltips{true};
     bool m_limit_tooltips_to_clipped_items{true};
     HWND m_wnd_tooltip{nullptr};
-    RECT m_rc_tooltip{0};
+    RECT m_tooltip_text_rect{};
+    RECT m_tooltip_placement_rect{};
+    float m_tooltip_text_left_offset{};
     size_t m_tooltip_last_index{std::numeric_limits<size_t>::max()};
     size_t m_tooltip_last_column{std::numeric_limits<size_t>::max()};
 

--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -372,21 +372,6 @@ void lv::DefaultRenderer::render_background(RendererContext context, const RECT*
     FillRect(context.dc, rc, wil::unique_hbrush(CreateSolidBrush(context.colours.m_background)).get());
 }
 
-int ListView::get_tooltip_text_width(const char* text, size_t length) const
-{
-    int ret = 0;
-    HDC hdc = GetDC(get_wnd());
-
-    if (hdc) {
-        HFONT fnt_old = SelectFont(hdc, m_items_font.get());
-        ret = uih::get_text_width(hdc, text, gsl::narrow<int>(strlen(text)));
-        SelectFont(hdc, fnt_old);
-        ReleaseDC(get_wnd(), hdc);
-    }
-
-    return ret;
-}
-
 bool ListView::is_item_clipped(size_t index, size_t column)
 {
     if (!m_items_text_format)
@@ -394,7 +379,7 @@ bool ListView::is_item_clipped(size_t index, size_t column)
 
     const pfc::string8 text = get_item_text(index, column);
     const auto render_text = uih::remove_colour_codes({text.c_str(), text.get_length()});
-    const auto text_width = m_items_text_format->measure_text_width(render_text);
+    const auto text_width = m_items_text_format->measure_text_width(mmh::to_utf16(render_text));
     const auto col_width = m_columns[column].m_display_size;
     return text_width + 3_spx * 2 + 1_spx > col_width;
 }

--- a/list_view/list_view_tooltip.cpp
+++ b/list_view/list_view_tooltip.cpp
@@ -1,5 +1,7 @@
 #include "stdafx.h"
 
+using namespace uih::literals::spx;
+
 namespace uih {
 
 void ListView::set_show_tooltips(bool b_val)
@@ -16,26 +18,35 @@ void ListView::create_tooltip(/*size_t index, size_t column, */ const char* str)
 {
     destroy_tooltip();
 
-    bool b_comctl_6 = true;
+    m_wnd_tooltip = CreateWindowEx(WS_EX_TRANSPARENT, TOOLTIPS_CLASS, nullptr, WS_POPUP | TTS_NOPREFIX | TTS_ALWAYSTIP,
+        CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, get_wnd(), nullptr, wil::GetModuleInstanceHandle(),
+        nullptr);
 
-    m_wnd_tooltip = CreateWindowEx(b_comctl_6 ? WS_EX_TRANSPARENT : 0, TOOLTIPS_CLASS, nullptr,
-        WS_POPUP | TTS_NOPREFIX | TTS_ALWAYSTIP | TTS_NOPREFIX, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
-        CW_USEDEFAULT, get_wnd(), nullptr, mmh::get_current_instance(), nullptr);
+    if (!m_wnd_tooltip)
+        return;
 
     set_tooltip_window_theme();
-    SendMessage(m_wnd_tooltip, WM_SETFONT, (WPARAM)m_items_font.get(), MAKELPARAM(FALSE, 0));
+
+    if (IsThemeActive() && IsAppThemed())
+        m_tooltip_theme.reset(OpenThemeData(m_wnd_tooltip, L"Tooltip"));
+
+    uih::subclass_window(m_wnd_tooltip, [this](auto wnd, auto msg, auto wp, auto lp) {
+        if (msg == WM_THEMECHANGED && IsThemeActive() && IsAppThemed())
+            m_tooltip_theme.reset(OpenThemeData(m_wnd_tooltip, L"Tooltip"));
+
+        return std::nullopt;
+    });
 
     RECT rect;
     GetClientRect(get_wnd(), &rect);
 
     pfc::stringcvt::string_wide_from_utf8 wstr(str);
-    TOOLINFO ti;
-    memset(&ti, 0, sizeof(ti));
+    TOOLINFO ti{};
 
     ti.cbSize = sizeof(TOOLINFO);
     ti.uFlags = TTF_TRANSPARENT | TTF_SUBCLASS;
     ti.hwnd = get_wnd();
-    ti.hinst = mmh::get_current_instance();
+    ti.hinst = wil::GetModuleInstanceHandle();
     ti.uId = IDC_TOOLTIP;
     ti.lpszText = const_cast<wchar_t*>(wstr.get_ptr());
     ti.rect = rect;
@@ -49,6 +60,7 @@ void ListView::destroy_tooltip()
         DestroyWindow(m_wnd_tooltip);
         m_wnd_tooltip = nullptr;
     }
+    m_tooltip_theme.reset();
     m_tooltip_last_index = -1;
     m_tooltip_last_column = -1;
 }
@@ -59,6 +71,119 @@ void ListView::set_tooltip_window_theme() const
         return;
 
     SetWindowTheme(m_wnd_tooltip, m_use_dark_mode ? L"DarkMode_Explorer" : nullptr, nullptr);
+}
+
+void ListView::calculate_tooltip_position(size_t item_index, size_t column_index, std::string_view text)
+{
+    int cx = get_total_indentation();
+
+    for (auto index : std::ranges::views::iota(size_t{}, column_index))
+        cx += m_columns[index].m_display_size;
+
+    POINT top_left;
+    top_left.x = cx + 1_spx + 3_spx - m_horizontal_scroll_position;
+    top_left.y = (get_item_position(item_index) - m_scroll_position) + get_items_top();
+    ClientToScreen(get_wnd(), &top_left);
+
+    const auto& column = m_columns[column_index];
+
+    try {
+        m_items_text_format->set_alignment(direct_write::get_text_alignment(column.m_alignment));
+        m_items_text_format->enable_trimming_sign();
+    }
+    CATCH_LOG()
+
+    const auto utf16_text = mmh::to_utf16(text);
+    const auto text_width = m_items_text_format->measure_text_width(utf16_text);
+
+    const auto max_width = static_cast<float>(column.m_display_size - 1_spx - 3_spx * 2)
+        / direct_write::TextLayout::s_default_scaling_factor();
+    const auto metrics = m_items_text_format->measure_text_position(utf16_text, m_item_height, max_width);
+
+    m_tooltip_text_left_offset = metrics.left_remainder_dip;
+
+    m_tooltip_placement_rect
+        = {top_left.x + metrics.left, top_left.y, top_left.x + metrics.left + text_width, top_left.y + m_item_height};
+
+    m_tooltip_text_rect.top = top_left.y + metrics.top;
+    m_tooltip_text_rect.bottom = top_left.y + metrics.height + 4_spx;
+    m_tooltip_text_rect.left = top_left.x + metrics.left;
+    m_tooltip_text_rect.right = m_tooltip_text_rect.left + text_width;
+}
+
+std::optional<LRESULT> ListView::on_wm_notify_tooltip(LPNMHDR lpnm)
+{
+    switch (lpnm->code) {
+    case NM_CUSTOMDRAW: {
+        const auto lpttcd = reinterpret_cast<LPNMTTCUSTOMDRAW>(lpnm);
+        switch (lpttcd->nmcd.dwDrawStage) {
+        case CDDS_PREPAINT: {
+            if (!m_tooltip_theme) {
+                const auto back_colour
+                    = static_cast<COLORREF>(SendMessage(lpttcd->nmcd.hdr.hwndFrom, TTM_GETTIPBKCOLOR, 0, 0));
+                SetTextColor(lpttcd->nmcd.hdc, back_colour);
+                return CDRF_NOTIFYPOSTPAINT;
+            }
+
+            RECT rc_background = lpttcd->nmcd.rc;
+            SendMessage(m_wnd_tooltip, TTM_ADJUSTRECT, TRUE, reinterpret_cast<LPARAM>(&rc_background));
+
+            DrawThemeBackground(
+                m_tooltip_theme.get(), lpttcd->nmcd.hdc, TTP_STANDARD, TTSS_NORMAL, &rc_background, &rc_background);
+
+            render_tooltip_text(lpttcd->nmcd.hdr.hwndFrom, lpttcd->nmcd.hdc, GetTextColor(lpttcd->nmcd.hdc));
+
+            return CDRF_SKIPDEFAULT;
+        }
+        case CDDS_POSTPAINT: {
+            if (!m_tooltip_theme) {
+                const auto text_colour
+                    = static_cast<COLORREF>(SendMessage(lpttcd->nmcd.hdr.hwndFrom, TTM_GETTIPTEXTCOLOR, 0, 0));
+
+                render_tooltip_text(lpttcd->nmcd.hdr.hwndFrom, lpttcd->nmcd.hdc, text_colour);
+            }
+
+            return CDRF_DODEFAULT;
+        }
+        }
+        break;
+    }
+    case TTN_SHOW: {
+        RECT rc = m_tooltip_text_rect;
+
+        SendMessage(m_wnd_tooltip, TTM_ADJUSTRECT, TRUE, reinterpret_cast<LPARAM>(&rc));
+
+        SetWindowPos(m_wnd_tooltip, nullptr, rc.left, rc.top, RECT_CX(rc), RECT_CY(rc), SWP_NOZORDER | SWP_NOACTIVATE);
+        return TRUE;
+    }
+    }
+    return {};
+}
+
+void ListView::render_tooltip_text(HWND wnd, HDC dc, COLORREF colour) const
+{
+    if (!m_items_text_format)
+        return;
+
+    auto text = get_window_text(wnd);
+
+    RECT rc_text = m_tooltip_placement_rect;
+    MapWindowPoints(HWND_DESKTOP, wnd, reinterpret_cast<LPPOINT>(&rc_text), 2);
+
+    if (m_items_text_format) {
+        try {
+            m_items_text_format->disable_trimming_sign();
+            m_items_text_format->set_alignment();
+            const auto scaling_factor = direct_write::TextLayout::s_default_scaling_factor();
+
+            const auto text_layout = m_items_text_format->create_text_layout(text,
+                gsl::narrow_cast<float>(wil::rect_width(rc_text)) / scaling_factor,
+                gsl::narrow_cast<float>(wil::rect_height(rc_text)) / scaling_factor);
+
+            text_layout.render(dc, rc_text, colour, m_tooltip_text_left_offset);
+        }
+        CATCH_LOG()
+    }
 }
 
 } // namespace uih

--- a/stdafx.h
+++ b/stdafx.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <span>
 #include <string>
 #include <type_traits>

--- a/win32_helpers.h
+++ b/win32_helpers.h
@@ -90,7 +90,8 @@ HWND handle_tab_down(HWND wnd);
  * \return              Window rect of wnd in wnd_parent co-ordinate space
  */
 RECT get_relative_rect(HWND wnd, HWND wnd_parent);
-bool get_window_text(HWND wnd, pfc::string_base& out);
+std::wstring get_window_text(HWND wnd);
+void get_window_text(HWND wnd, pfc::string_base& out);
 void set_window_font(HWND wnd, HFONT font, bool redraw = true);
 HFONT get_window_font(HWND wnd);
 


### PR DESCRIPTION
This renders list view tooltips using DirectWrite. This is achieved using custom draw logic.

The positioning of tooltips for centre- and right-aligned columns was also improved.