### PR TITLE
Fix clipped italics when rendering text using DirectWrite

### DIFF
--- a/direct_write.h
+++ b/direct_write.h
@@ -18,6 +18,7 @@ public:
     }
 
     DWRITE_TEXT_METRICS get_metrics() const;
+    DWRITE_OVERHANG_METRICS get_overhang_metrics() const;
     void render(HDC dc, RECT rect, COLORREF default_colour, float x_origin_offset = 0.0f) const;
     void set_colour(COLORREF colour, DWRITE_TEXT_RANGE text_range) const;
 


### PR DESCRIPTION
This resolves a problem (while maintaining previous optimisations) where, in some cases (such as italics), text was clipped at the right edge when rendered using DirectWrite.