### PR TITLE
Throw exception if DPI-aware metrics unavailable

### DIFF
--- a/dpi.cpp
+++ b/dpi.cpp
@@ -6,13 +6,13 @@ BOOL system_parameters_info_for_dpi(unsigned action, unsigned param, void* data,
 {
     using SystemParametersInfoForDpiProc = BOOL(__stdcall*)(UINT, UINT, PVOID, UINT, UINT);
 
-    const wil::unique_hmodule user32(THROW_LAST_ERROR_IF_NULL(LoadLibrary(L"user32.dll")));
+    const wil::unique_hmodule user32(LOG_LAST_ERROR_IF_NULL(LoadLibrary(L"user32.dll")));
 
     const auto system_parameters_info_for_dpi_proc
         = reinterpret_cast<SystemParametersInfoForDpiProc>(GetProcAddress(user32.get(), "SystemParametersInfoForDpi"));
 
     if (!system_parameters_info_for_dpi_proc)
-        return SystemParametersInfo(action, param, data, 0);
+        throw DpiAwareFunctionUnavailableError();
 
     return system_parameters_info_for_dpi_proc(action, param, data, 0, dpi);
 }
@@ -21,13 +21,13 @@ BOOL system_parameters_info_for_dpi(unsigned action, unsigned param, void* data,
 {
     using GetSystemMetricsForDpiProc = int(__stdcall*)(int, UINT);
 
-    const wil::unique_hmodule user32(THROW_LAST_ERROR_IF_NULL(LoadLibrary(L"user32.dll")));
+    const wil::unique_hmodule user32(LOG_LAST_ERROR_IF_NULL(LoadLibrary(L"user32.dll")));
 
     const auto get_system_metrics_for_dpi_proc
         = reinterpret_cast<GetSystemMetricsForDpiProc>(GetProcAddress(user32.get(), "GetSystemMetricsForDpi"));
 
     if (!get_system_metrics_for_dpi_proc)
-        return GetSystemMetrics(index);
+        throw DpiAwareFunctionUnavailableError();
 
     return get_system_metrics_for_dpi_proc(index, dpi);
 }

--- a/dpi.h
+++ b/dpi.h
@@ -2,6 +2,11 @@
 
 namespace uih::dpi {
 
+class DpiAwareFunctionUnavailableError : public std::exception {
+public:
+    [[nodiscard]] const char* what() const override { return "This DPI-aware function is not available."; }
+};
+
 template <class Value, class ReleaseFunc>
 class DpiContextHandle {
 public:


### PR DESCRIPTION
This changes the logic in some DPI-aware metrics helpers so that an exception is thrown if DPI-aware metrics are unavailable (rather than simply returning the non-DPI-aware value).

This is to allow the caller to handle the situation more appropriately (e.g. scale the non-DPI-aware value).