### PR TITLE
Add additional font family and face look-up helpers

### DIFF
--- a/direct_write.h
+++ b/direct_write.h
@@ -93,16 +93,29 @@ public:
 
     Context();
 
+    const wil::com_ptr_t<IDWriteFactory1>& factory() { return m_factory; }
+
     LOGFONT create_log_font(const wil::com_ptr_t<IDWriteFont>& font) const;
     wil::com_ptr_t<IDWriteFont> create_font(const LOGFONT& log_font) const;
     TextFormat create_text_format(const wil::com_ptr_t<IDWriteFont>& font, float font_size);
-    TextFormat create_text_format(const wil::com_ptr_t<IDWriteFontFamily>& font_family, DWRITE_FONT_WEIGHT font_weight,
-        DWRITE_FONT_STYLE font_style, DWRITE_FONT_STRETCH font_stretch, float font_size);
+
+    TextFormat create_text_format(const wil::com_ptr_t<IDWriteFontFamily>& font_family, DWRITE_FONT_WEIGHT weight,
+        DWRITE_FONT_STRETCH stretch, DWRITE_FONT_STYLE style, float font_size);
+
+    TextFormat create_text_format(const wchar_t* family_name, DWRITE_FONT_WEIGHT weight, DWRITE_FONT_STRETCH stretch,
+        DWRITE_FONT_STYLE style, float font_size);
+
     TextFormat create_text_format(const LOGFONT& log_font, float font_size);
+
     std::optional<TextFormat> create_text_format_with_fallback(
-        const LOGFONT& log_font, std::optional<float> font_size) noexcept;
-    TextFormat create_icon_font_text_format(std::optional<float> font_size);
+        const LOGFONT& log_font, std::optional<float> font_size = {}) noexcept;
+
+    TextFormat wrap_text_format(wil::com_ptr_t<IDWriteTextFormat> text_format);
+
     wil::com_ptr_t<IDWriteTypography> get_default_typography();
+
+    std::optional<std::wstring> get_face_name(const wchar_t* family_name, DWRITE_FONT_WEIGHT weight,
+        DWRITE_FONT_STRETCH stretch, DWRITE_FONT_STYLE style) const;
     std::vector<FontFamily> get_font_families() const;
 
 private:

--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -227,8 +227,10 @@ public:
         m_dark_edit_background_colour = background_colour;
     }
     void set_vertical_item_padding(int val);
-    void set_font(const LOGFONT& log_font, std::optional<float> font_size = std::nullopt);
-    void set_group_font(const LOGFONT& log_font, std::optional<float> font_size = std::nullopt);
+    void set_font_from_log_font(const LOGFONT& log_font);
+    void set_font(wil::com_ptr_t<IDWriteTextFormat> text_format, const LOGFONT& log_font);
+    void set_font(std::optional<direct_write::TextFormat> text_format, const LOGFONT& log_font);
+    void set_group_font(wil::com_ptr_t<IDWriteTextFormat> text_format);
     void set_header_font(const LOGFONT& log_font);
     void set_sorting_enabled(bool b_val);
     void set_show_sort_indicators(bool b_val);
@@ -700,9 +702,9 @@ protected:
     void focus_search_box();
 
 private:
-    struct FontConfig {
+    struct ItemsFontConfig {
+        wil::com_ptr_t<IDWriteTextFormat> text_format;
         LOGFONT log_font{};
-        std::optional<float> size;
     };
 
     virtual void on_first_show();
@@ -872,8 +874,7 @@ private:
     COLORREF m_dark_edit_background_colour{};
     COLORREF m_dark_edit_text_colour{RGB(255, 255, 255)};
 
-    std::optional<FontConfig> m_items_font_config{};
-    std::optional<FontConfig> m_group_font_config{};
+    std::optional<LOGFONT> m_items_log_font{};
     std::optional<LOGFONT> m_header_log_font{};
     direct_write::Context::Ptr m_direct_write_context;
     std::optional<direct_write::TextFormat> m_items_text_format;

--- a/list_view/list_view_drag_image.cpp
+++ b/list_view/list_view_drag_image.cpp
@@ -13,8 +13,8 @@ bool ListView::render_drag_image(LPSHDRAGIMAGE lpsdi)
     auto icon = get_drag_image_icon();
 
     LOGFONT lf{};
-    if (m_items_font_config)
-        lf = m_items_font_config->log_font;
+    if (m_items_log_font)
+        lf = *m_items_log_font;
     else
         GetObject(m_items_font.get(), sizeof(lf), &lf);
 

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -31,14 +31,19 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         set_window_theme();
         reopen_themes();
 
-        if (!m_items_font_config || !m_group_font_config) {
+        if (!m_items_log_font || !m_group_text_format) {
             LOGFONT icon_font{};
             if (SystemParametersInfo(SPI_GETICONTITLELOGFONT, 0, &icon_font, 0)) {
-                if (!m_items_font_config)
-                    m_items_font_config = {icon_font};
+                if (!m_items_log_font) {
+                    m_items_log_font = icon_font;
 
-                if (!m_group_font_config)
-                    m_group_font_config = {icon_font};
+                    if (m_direct_write_context) {
+                        m_items_text_format = m_direct_write_context->create_text_format_with_fallback(icon_font);
+                    }
+                }
+
+                if (!m_group_text_format && m_direct_write_context)
+                    m_group_text_format = m_items_text_format;
             }
         }
 


### PR DESCRIPTION
This makes some changes to the DirectWrite helpers to facilitate serialisation and deserialisation of font family names and weight, stretch and style properties (and hence recreating text formats after deserialisation).

Furthermore, adjustments were made to the list view so that DirectWrite text formats can be specified where DirectWrite is used for text rendering.