### PR TITLE
Correct list view group title height

### DIFF
--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -278,7 +278,7 @@ int ListView::get_default_item_height()
 
 int ListView::get_default_group_height()
 {
-    const auto font_height = m_group_text_format ? m_items_text_format->get_minimum_height() : 0;
+    const auto font_height = m_group_text_format ? m_group_text_format->get_minimum_height() : 0;
     int ret = font_height + m_vertical_item_padding;
     if (ret < 1)
         ret = 1;


### PR DESCRIPTION
reupen/columns_ui#923

This resolves a regression in 8702284fadca243aaf9ee1ef67c96d7d41218978 where list view group titles were using a height based on the items font, rather than the group font.