### PR TITLE
Fix problem displaying tooltips in a near zero-width list view column

### DIFF
--- a/list_view/list_view_tooltip.cpp
+++ b/list_view/list_view_tooltip.cpp
@@ -96,8 +96,8 @@ void ListView::calculate_tooltip_position(size_t item_index, size_t column_index
     const auto utf16_text = mmh::to_utf16(text);
     const auto text_width = m_items_text_format->measure_text_width(utf16_text);
 
-    const auto max_width
-        = static_cast<float>(column.m_display_size - 1_spx - 3_spx * 2) / direct_write::get_default_scaling_factor();
+    const auto max_width = std::max(0.0f,
+        static_cast<float>(column.m_display_size - 1_spx - 3_spx * 2) / direct_write::get_default_scaling_factor());
     const auto metrics = m_items_text_format->measure_text_position(utf16_text, m_item_height, max_width);
 
     m_tooltip_text_left_offset = metrics.left_remainder_dip;


### PR DESCRIPTION
This resolves a problem where tooltips were not displayed for a near zero-width column due to the calculated column text area width being negative.