### PR TITLE
Add additional formatting options to DirectWrite text renderer

### DIFF
--- a/direct_write.h
+++ b/direct_write.h
@@ -12,10 +12,20 @@ public:
     {
     }
 
+    float get_max_height() const noexcept;
+    float get_max_width() const noexcept;
     DWRITE_TEXT_METRICS get_metrics() const;
     DWRITE_OVERHANG_METRICS get_overhang_metrics() const;
-    void render(HDC dc, RECT rect, COLORREF default_colour, float x_origin_offset = 0.0f) const;
+    void render_with_transparent_background(
+        HDC dc, RECT output_rect, COLORREF default_colour, float x_origin_offset = 0.0f) const;
+    void render_with_solid_background(HDC dc, float x_origin, float y_origin, RECT clip_rect,
+        COLORREF background_colour, COLORREF default_text_colour) const;
     void set_colour(COLORREF colour, DWRITE_TEXT_RANGE text_range) const;
+    void set_max_height(float value) const;
+    void set_max_width(float value) const;
+    void set_underline(bool is_underlined, DWRITE_TEXT_RANGE text_range) const;
+    void set_font(const wchar_t* font_family, DWRITE_FONT_WEIGHT weight, DWRITE_FONT_STRETCH stretch,
+        DWRITE_FONT_STYLE style, float size, DWRITE_TEXT_RANGE text_range) const;
 
 private:
     wil::com_ptr_t<IDWriteFactory> m_factory;
@@ -34,18 +44,18 @@ struct TextPosition {
 class TextFormat {
 public:
     TextFormat(std::shared_ptr<class Context> context, wil::com_ptr_t<IDWriteFactory> factory,
-        wil::com_ptr_t<IDWriteGdiInterop> gdi_interop, wil::com_ptr_t<IDWriteTextFormat> text_format,
-        wil::com_ptr_t<IDWriteInlineObject> trimming_sign)
+        wil::com_ptr_t<IDWriteGdiInterop> gdi_interop, wil::com_ptr_t<IDWriteTextFormat> text_format)
         : m_context(std::move(context))
         , m_factory(std::move(factory))
         , m_gdi_interop(std::move(gdi_interop))
         , m_text_format(std::move(text_format))
-        , m_trimming_sign(std::move(trimming_sign))
     {
     }
 
-    void set_alignment(DWRITE_TEXT_ALIGNMENT alignment = DWRITE_TEXT_ALIGNMENT_LEADING) const;
-    void enable_trimming_sign() const;
+    void set_text_alignment(DWRITE_TEXT_ALIGNMENT value = DWRITE_TEXT_ALIGNMENT_LEADING) const;
+    void set_paragraph_alignment(DWRITE_PARAGRAPH_ALIGNMENT value) const;
+    void set_word_wrapping(DWRITE_WORD_WRAPPING value) const;
+    void enable_trimming_sign();
     void disable_trimming_sign() const;
 
     [[nodiscard]] int get_minimum_height(std::wstring_view text = std::wstring_view(L"", 0)) const;
@@ -110,7 +120,7 @@ public:
     std::optional<TextFormat> create_text_format_with_fallback(
         const LOGFONT& log_font, std::optional<float> font_size = {}) noexcept;
 
-    TextFormat wrap_text_format(wil::com_ptr_t<IDWriteTextFormat> text_format);
+    TextFormat wrap_text_format(wil::com_ptr_t<IDWriteTextFormat> text_format, bool set_defaults = true);
 
     wil::com_ptr_t<IDWriteTypography> get_default_typography();
 

--- a/direct_write_text_out.cpp
+++ b/direct_write_text_out.cpp
@@ -16,7 +16,7 @@ int text_out_colours(const TextFormat& text_format, HDC dc, std::string_view tex
         ? process_colour_codes(mmh::to_utf16(text), selected)
         : std::tuple(mmh::to_utf16(text), std::vector<ColouredTextSegment>{});
 
-    text_format.set_alignment(get_text_alignment(align));
+    text_format.set_text_alignment(get_text_alignment(align));
 
     try {
         const auto scaling_factor = get_default_scaling_factor();
@@ -31,7 +31,7 @@ int text_out_colours(const TextFormat& text_format, HDC dc, std::string_view tex
 
         const auto metrics = layout.get_metrics();
 
-        layout.render(dc, rect, default_color);
+        layout.render_with_transparent_background(dc, rect, default_color);
 
         return gsl::narrow_cast<int>(metrics.width * scaling_factor + 1);
     }
@@ -54,7 +54,7 @@ DWRITE_TEXT_ALIGNMENT get_text_alignment(alignment alignment_)
     }
 }
 
-int text_out_columns_and_colours(const TextFormat& text_format, HDC dc, std::string_view text, int x_offset, int border,
+int text_out_columns_and_colours(TextFormat& text_format, HDC dc, std::string_view text, int x_offset, int border,
     const RECT& rect, bool selected, COLORREF default_colour, bool enable_colour_codes, bool enable_tab_columns,
     alignment align, bool enable_ellipses)
 {

--- a/direct_write_text_out.h
+++ b/direct_write_text_out.h
@@ -4,7 +4,7 @@ namespace uih::direct_write {
 
 DWRITE_TEXT_ALIGNMENT get_text_alignment(alignment alignment_);
 
-int text_out_columns_and_colours(const TextFormat& text_format, HDC dc, std::string_view text, int x_offset, int border,
+int text_out_columns_and_colours(TextFormat& text_format, HDC dc, std::string_view text, int x_offset, int border,
     const RECT& rect, bool selected, COLORREF default_colour, bool enable_colour_codes, bool enable_tab_columns,
     alignment align = uih::ALIGN_LEFT, bool enable_ellipses = true);
 

--- a/list_view/list_view_tooltip.cpp
+++ b/list_view/list_view_tooltip.cpp
@@ -88,7 +88,7 @@ void ListView::calculate_tooltip_position(size_t item_index, size_t column_index
     const auto& column = m_columns[column_index];
 
     try {
-        m_items_text_format->set_alignment(direct_write::get_text_alignment(column.m_alignment));
+        m_items_text_format->set_text_alignment(direct_write::get_text_alignment(column.m_alignment));
         m_items_text_format->enable_trimming_sign();
     }
     CATCH_LOG()
@@ -173,14 +173,14 @@ void ListView::render_tooltip_text(HWND wnd, HDC dc, COLORREF colour) const
     if (m_items_text_format) {
         try {
             m_items_text_format->disable_trimming_sign();
-            m_items_text_format->set_alignment();
+            m_items_text_format->set_text_alignment();
             const auto scaling_factor = direct_write::get_default_scaling_factor();
 
             const auto text_layout = m_items_text_format->create_text_layout(text,
                 gsl::narrow_cast<float>(wil::rect_width(rc_text)) / scaling_factor,
                 gsl::narrow_cast<float>(wil::rect_height(rc_text)) / scaling_factor);
 
-            text_layout.render(dc, rc_text, colour, m_tooltip_text_left_offset);
+            text_layout.render_with_transparent_background(dc, rc_text, colour, m_tooltip_text_left_offset);
         }
         CATCH_LOG()
     }


### PR DESCRIPTION
This updates the DirectWrite text renderer to add additional output and formatting options such as word wrapping and underline support, and also add a new render method that renders text against a solid background without fitting the output bitmap to the text size.