### PR TITLE
Allow customisation of DirectWrite rendering parameters

### DIFF
--- a/direct_write.h
+++ b/direct_write.h
@@ -5,10 +5,13 @@ namespace uih::direct_write {
 class TextLayout {
 public:
     TextLayout(wil::com_ptr_t<IDWriteFactory> factory, wil::com_ptr_t<IDWriteGdiInterop> gdi_interop,
-        wil::com_ptr_t<IDWriteTextLayout> text_layout)
+        wil::com_ptr_t<IDWriteTextLayout> text_layout, DWRITE_RENDERING_MODE rendering_mode,
+        bool force_greyscale_antialiasing)
         : m_factory(std::move(factory))
         , m_gdi_interop(std::move(gdi_interop))
         , m_text_layout(std::move(text_layout))
+        , m_rendering_mode(rendering_mode)
+        , m_force_greyscale_antialiasing(force_greyscale_antialiasing)
     {
     }
 
@@ -28,9 +31,13 @@ public:
         DWRITE_FONT_STYLE style, float size, DWRITE_TEXT_RANGE text_range) const;
 
 private:
+    wil::com_ptr_t<IDWriteRenderingParams> create_rendering_params() const;
+
     wil::com_ptr_t<IDWriteFactory> m_factory;
     wil::com_ptr_t<IDWriteGdiInterop> m_gdi_interop;
     wil::com_ptr_t<IDWriteTextLayout> m_text_layout;
+    DWRITE_RENDERING_MODE m_rendering_mode{};
+    bool m_force_greyscale_antialiasing{};
 };
 
 struct TextPosition {
@@ -44,11 +51,14 @@ struct TextPosition {
 class TextFormat {
 public:
     TextFormat(std::shared_ptr<class Context> context, wil::com_ptr_t<IDWriteFactory> factory,
-        wil::com_ptr_t<IDWriteGdiInterop> gdi_interop, wil::com_ptr_t<IDWriteTextFormat> text_format)
+        wil::com_ptr_t<IDWriteGdiInterop> gdi_interop, wil::com_ptr_t<IDWriteTextFormat> text_format,
+        DWRITE_RENDERING_MODE rendering_mode, bool force_greyscale_antialiasing)
         : m_context(std::move(context))
         , m_factory(std::move(factory))
         , m_gdi_interop(std::move(gdi_interop))
         , m_text_format(std::move(text_format))
+        , m_rendering_mode(rendering_mode)
+        , m_force_greyscale_antialiasing(force_greyscale_antialiasing)
     {
     }
 
@@ -70,6 +80,8 @@ private:
     wil::com_ptr_t<IDWriteGdiInterop> m_gdi_interop;
     wil::com_ptr_t<IDWriteTextFormat> m_text_format;
     wil::com_ptr_t<IDWriteInlineObject> m_trimming_sign;
+    DWRITE_RENDERING_MODE m_rendering_mode{};
+    bool m_force_greyscale_antialiasing{};
 };
 
 struct Font {
@@ -120,7 +132,9 @@ public:
     std::optional<TextFormat> create_text_format_with_fallback(
         const LOGFONT& log_font, std::optional<float> font_size = {}) noexcept;
 
-    TextFormat wrap_text_format(wil::com_ptr_t<IDWriteTextFormat> text_format, bool set_defaults = true);
+    TextFormat wrap_text_format(wil::com_ptr_t<IDWriteTextFormat> text_format,
+        DWRITE_RENDERING_MODE rendering_mode = DWRITE_RENDERING_MODE_DEFAULT, bool force_greyscale_antialiasing = false,
+        bool set_defaults = true);
 
     wil::com_ptr_t<IDWriteTypography> get_default_typography();
 

--- a/direct_write_text_out.cpp
+++ b/direct_write_text_out.cpp
@@ -55,8 +55,7 @@ DWRITE_TEXT_ALIGNMENT get_text_alignment(alignment alignment_)
 }
 
 int text_out_columns_and_colours(TextFormat& text_format, HDC dc, std::string_view text, int x_offset, int border,
-    const RECT& rect, bool selected, COLORREF default_colour, bool enable_colour_codes, bool enable_tab_columns,
-    alignment align, bool enable_ellipses)
+    const RECT& rect, COLORREF default_colour, TextOutOptions options)
 {
     RECT adjusted_rect = rect;
 
@@ -65,7 +64,7 @@ int text_out_columns_and_colours(TextFormat& text_format, HDC dc, std::string_vi
 
     int tab_count = 0;
 
-    if (enable_tab_columns) {
+    if (options.enable_tab_columns) {
         for (size_t n = 0; n < text.length(); n++) {
             if (text[n] == '\t') {
                 tab_count++;
@@ -77,13 +76,13 @@ int text_out_columns_and_colours(TextFormat& text_format, HDC dc, std::string_vi
         adjusted_rect.left += border + x_offset;
         adjusted_rect.right -= border;
 
-        if (enable_ellipses)
+        if (options.enable_ellipses)
             text_format.enable_trimming_sign();
         else
             text_format.disable_trimming_sign();
 
-        return text_out_colours(
-            text_format, dc, text, adjusted_rect, selected, default_colour, align, enable_colour_codes);
+        return text_out_colours(text_format, dc, text, adjusted_rect, options.is_selected, default_colour,
+            options.align, options.enable_colour_codes);
     }
 
     // Ellipses always disabled when using tab columns
@@ -110,8 +109,8 @@ int text_out_columns_and_colours(TextFormat& text_format, HDC dc, std::string_vi
                 cell_rect.left = std::min(
                     adjusted_rect.right - MulDiv(cell_index, total_width, tab_count) + border, cell_rect.right);
 
-            const int cell_render_width = text_out_colours(text_format, dc, cell_text, cell_rect, selected,
-                default_colour, cell_index == 0 ? ALIGN_RIGHT : ALIGN_LEFT, enable_colour_codes);
+            const int cell_render_width = text_out_colours(text_format, dc, cell_text, cell_rect, options.is_selected,
+                default_colour, cell_index == 0 ? ALIGN_RIGHT : ALIGN_LEFT, options.enable_colour_codes);
 
             if (cell_index == 0)
                 cell_rect.left = cell_rect.right - cell_render_width;

--- a/direct_write_text_out.h
+++ b/direct_write_text_out.h
@@ -4,8 +4,15 @@ namespace uih::direct_write {
 
 DWRITE_TEXT_ALIGNMENT get_text_alignment(alignment alignment_);
 
+struct TextOutOptions {
+    bool is_selected{};
+    alignment align{ALIGN_LEFT};
+    bool enable_ellipses{};
+    bool enable_colour_codes{true};
+    bool enable_tab_columns{true};
+};
+
 int text_out_columns_and_colours(TextFormat& text_format, HDC dc, std::string_view text, int x_offset, int border,
-    const RECT& rect, bool selected, COLORREF default_colour, bool enable_colour_codes, bool enable_tab_columns,
-    alignment align = uih::ALIGN_LEFT, bool enable_ellipses = true);
+    const RECT& rect, COLORREF default_colour, TextOutOptions options = {});
 
 } // namespace uih::direct_write

--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -230,9 +230,8 @@ public:
     }
     void set_vertical_item_padding(int val);
     void set_font_from_log_font(const LOGFONT& log_font);
-    void set_font(wil::com_ptr_t<IDWriteTextFormat> text_format, const LOGFONT& log_font);
     void set_font(std::optional<direct_write::TextFormat> text_format, const LOGFONT& log_font);
-    void set_group_font(wil::com_ptr_t<IDWriteTextFormat> text_format);
+    void set_group_font(std::optional<direct_write::TextFormat> text_format);
     void set_header_font(const LOGFONT& log_font);
     void set_sorting_enabled(bool b_val);
     void set_show_sort_indicators(bool b_val);

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -616,20 +616,6 @@ void ListView::set_font_from_log_font(const LOGFONT& log_font)
     set_font(text_format, log_font);
 }
 
-void ListView::set_font(wil::com_ptr_t<IDWriteTextFormat> text_format, const LOGFONT& log_font)
-{
-    std::optional<direct_write::TextFormat> wrapped_text_format;
-
-    if (m_direct_write_context && text_format) {
-        try {
-            wrapped_text_format = m_direct_write_context->wrap_text_format(std::move(text_format));
-        }
-        CATCH_LOG()
-    }
-
-    set_font(wrapped_text_format, log_font);
-}
-
 void ListView::set_font(std::optional<direct_write::TextFormat> text_format, const LOGFONT& log_font)
 {
     m_items_log_font = log_font;
@@ -648,16 +634,9 @@ void ListView::set_font(std::optional<direct_write::TextFormat> text_format, con
     }
 }
 
-void ListView::set_group_font(wil::com_ptr_t<IDWriteTextFormat> text_format)
+void ListView::set_group_font(std::optional<direct_write::TextFormat> text_format)
 {
-    m_group_text_format.reset();
-
-    if (m_direct_write_context && text_format) {
-        try {
-            m_group_text_format = m_direct_write_context->wrap_text_format(std::move(text_format));
-        }
-        CATCH_LOG()
-    }
+    m_group_text_format = text_format;
 
     if (m_initialised) {
         exit_inline_edit();

--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -235,7 +235,7 @@ void lv::DefaultRenderer::render_group(RendererContext context, size_t item_inde
     const auto x_offset = 1_spx + indentation * gsl::narrow<int>(level);
     const auto border = 3_spx;
     const auto text_width = direct_write::text_out_columns_and_colours(
-        *context.m_group_text_format, context.dc, text, x_offset, border, rc, false, cr, true, false);
+        *context.m_group_text_format, context.dc, text, x_offset, border, rc, cr, {.enable_tab_columns = false});
 
     const auto line_height = 1_spx;
     const auto line_top = rc.top + wil::rect_height(rc) / 2 - line_height / 2;
@@ -304,8 +304,10 @@ void lv::DefaultRenderer::render_item(RendererContext context, size_t index, std
 
         if (context.m_item_text_format)
             direct_write::text_out_columns_and_colours(*context.m_item_text_format, context.dc, sub_item.text,
-                1_spx + (column_index == 0 ? indentation : 0), 3_spx, rc_subitem, b_selected, cr_text, true,
-                m_enable_item_tab_columns, sub_item.alignment);
+                1_spx + (column_index == 0 ? indentation : 0), 3_spx, rc_subitem, cr_text,
+                {.is_selected = b_selected,
+                    .align = sub_item.alignment,
+                    .enable_tab_columns = m_enable_item_tab_columns});
 
         rc_subitem.left = rc_subitem.right;
     }


### PR DESCRIPTION
This allows the DirectWrite rendering mode and whether to force greyscale anti-aliasing to be configured when wrapping a text format object.

The signature of `uih::direct_write::text_out_columns_and_colours()` was also amended slightly to try and simplify usage.