### PR TITLE
Render list view header text using DirectWrite

### DIFF
--- a/direct_write_text_out.h
+++ b/direct_write_text_out.h
@@ -7,7 +7,7 @@ DWRITE_TEXT_ALIGNMENT get_text_alignment(alignment alignment_);
 struct TextOutOptions {
     bool is_selected{};
     alignment align{ALIGN_LEFT};
-    bool enable_ellipses{};
+    bool enable_ellipses{true};
     bool enable_colour_codes{true};
     bool enable_tab_columns{true};
 };

--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -232,7 +232,7 @@ public:
     void set_font_from_log_font(const LOGFONT& log_font);
     void set_font(std::optional<direct_write::TextFormat> text_format, const LOGFONT& log_font);
     void set_group_font(std::optional<direct_write::TextFormat> text_format);
-    void set_header_font(const LOGFONT& log_font);
+    void set_header_font(std::optional<direct_write::TextFormat> text_format, const LOGFONT& log_font);
     void set_sorting_enabled(bool b_val);
     void set_show_sort_indicators(bool b_val);
     void set_edge_style(uint32_t b_val);
@@ -879,6 +879,7 @@ private:
     std::optional<LOGFONT> m_header_log_font{};
     direct_write::Context::Ptr m_direct_write_context;
     std::optional<direct_write::TextFormat> m_items_text_format;
+    std::optional<direct_write::TextFormat> m_header_text_format;
     std::optional<direct_write::TextFormat> m_group_text_format;
 
     bool m_selecting{false};

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -634,6 +634,19 @@ void ListView::set_font(std::optional<direct_write::TextFormat> text_format, con
     }
 }
 
+void ListView::set_header_font(std::optional<direct_write::TextFormat> text_format, const LOGFONT& log_font)
+{
+    m_header_log_font = log_font;
+    m_header_text_format = std::move(text_format);
+
+    if (m_initialised && m_wnd_header) {
+        SetWindowFont(m_wnd_header, nullptr, FALSE);
+        m_header_font.reset(CreateFontIndirect(&log_font));
+        SetWindowFont(m_wnd_header, m_header_font.get(), TRUE);
+        on_size();
+    }
+}
+
 void ListView::set_group_font(std::optional<direct_write::TextFormat> text_format)
 {
     m_group_text_format = text_format;
@@ -658,18 +671,6 @@ void ListView::refresh_items_font()
 void ListView::refresh_group_font()
 {
     m_group_height = get_default_group_height();
-}
-
-void ListView::set_header_font(const LOGFONT& log_font)
-{
-    m_header_log_font = log_font;
-
-    if (m_initialised && m_wnd_header) {
-        SendMessage(m_wnd_header, WM_SETFONT, NULL, MAKELPARAM(FALSE, 0));
-        m_header_font.reset(CreateFontIndirect(&log_font));
-        SendMessage(m_wnd_header, WM_SETFONT, (WPARAM)m_header_font.get(), MAKELPARAM(TRUE, 0));
-        on_size();
-    }
 }
 
 void ListView::set_sorting_enabled(bool b_val)

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -42,6 +42,11 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     }
                 }
 
+                if (!m_header_log_font) {
+                    m_header_log_font = m_items_log_font;
+                    m_header_text_format = m_items_text_format;
+                }
+
                 if (!m_group_text_format && m_direct_write_context)
                     m_group_text_format = m_items_text_format;
             }
@@ -73,6 +78,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         m_items.clear();
         m_columns.clear();
         m_items_text_format.reset();
+        m_header_text_format.reset();
         m_group_text_format.reset();
         m_direct_write_context.reset();
         notify_on_destroy();


### PR DESCRIPTION
This uses a few tricks to get the column titles in the list view header rendered using DirectWrite.

No text is passed to the header control for each column, to stop the control rendering the text. The text can then be rendered using custom draw using DirectWrite.

Naturally this is a hack. (It may have a negative effect on accessibility, however accessibility is a general problem for the list view control already.)