### PR TITLE
Improve DirectWrite multi-monitor support

### DIFF
--- a/direct_write_text_out.cpp
+++ b/direct_write_text_out.cpp
@@ -6,8 +6,8 @@ namespace uih::direct_write {
 
 namespace {
 
-int text_out_colours(const TextFormat& text_format, HDC dc, std::string_view text, const RECT& rect, bool selected,
-    DWORD default_color, alignment align, bool enable_colour_codes)
+int text_out_colours(const TextFormat& text_format, HWND wnd, HDC dc, std::string_view text, const RECT& rect,
+    bool selected, DWORD default_color, alignment align, bool enable_colour_codes)
 {
     if (is_rect_null_or_reversed(&rect) || rect.right <= rect.left)
         return 0;
@@ -31,7 +31,7 @@ int text_out_colours(const TextFormat& text_format, HDC dc, std::string_view tex
 
         const auto metrics = layout.get_metrics();
 
-        layout.render_with_transparent_background(dc, rect, default_color);
+        layout.render_with_transparent_background(wnd, dc, rect, default_color);
 
         return gsl::narrow_cast<int>(metrics.width * scaling_factor + 1);
     }
@@ -54,8 +54,8 @@ DWRITE_TEXT_ALIGNMENT get_text_alignment(alignment alignment_)
     }
 }
 
-int text_out_columns_and_colours(TextFormat& text_format, HDC dc, std::string_view text, int x_offset, int border,
-    const RECT& rect, COLORREF default_colour, TextOutOptions options)
+int text_out_columns_and_colours(TextFormat& text_format, HWND wnd, HDC dc, std::string_view text, int x_offset,
+    int border, const RECT& rect, COLORREF default_colour, TextOutOptions options)
 {
     RECT adjusted_rect = rect;
 
@@ -81,7 +81,7 @@ int text_out_columns_and_colours(TextFormat& text_format, HDC dc, std::string_vi
         else
             text_format.disable_trimming_sign();
 
-        return text_out_colours(text_format, dc, text, adjusted_rect, options.is_selected, default_colour,
+        return text_out_colours(text_format, wnd, dc, text, adjusted_rect, options.is_selected, default_colour,
             options.align, options.enable_colour_codes);
     }
 
@@ -109,8 +109,9 @@ int text_out_columns_and_colours(TextFormat& text_format, HDC dc, std::string_vi
                 cell_rect.left = std::min(
                     adjusted_rect.right - MulDiv(cell_index, total_width, tab_count) + border, cell_rect.right);
 
-            const int cell_render_width = text_out_colours(text_format, dc, cell_text, cell_rect, options.is_selected,
-                default_colour, cell_index == 0 ? ALIGN_RIGHT : ALIGN_LEFT, options.enable_colour_codes);
+            const int cell_render_width
+                = text_out_colours(text_format, wnd, dc, cell_text, cell_rect, options.is_selected, default_colour,
+                    cell_index == 0 ? ALIGN_RIGHT : ALIGN_LEFT, options.enable_colour_codes);
 
             if (cell_index == 0)
                 cell_rect.left = cell_rect.right - cell_render_width;

--- a/direct_write_text_out.h
+++ b/direct_write_text_out.h
@@ -12,7 +12,7 @@ struct TextOutOptions {
     bool enable_tab_columns{true};
 };
 
-int text_out_columns_and_colours(TextFormat& text_format, HDC dc, std::string_view text, int x_offset, int border,
-    const RECT& rect, COLORREF default_colour, TextOutOptions options = {});
+int text_out_columns_and_colours(TextFormat& text_format, HWND wnd, HDC dc, std::string_view text, int x_offset,
+    int border, const RECT& rect, COLORREF default_colour, TextOutOptions options = {});
 
 } // namespace uih::direct_write

--- a/list_view/list_view_header.cpp
+++ b/list_view/list_view_header.cpp
@@ -129,7 +129,7 @@ std::optional<LRESULT> ListView::on_wm_notify_header(LPNMHDR lpnm)
             if (m_header_text_format) {
                 const auto& column = m_columns[index];
 
-                direct_write::text_out_columns_and_colours(*m_header_text_format, lpcd->hdc,
+                direct_write::text_out_columns_and_colours(*m_header_text_format, get_wnd(), lpcd->hdc,
                     mmh::to_string_view(column.m_title), 0, 4_spx, lpcd->rc, cr,
                     {.align = column.m_alignment, .enable_colour_codes = false, .enable_tab_columns = false});
             }

--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -234,8 +234,8 @@ void lv::DefaultRenderer::render_group(RendererContext context, size_t item_inde
 
     const auto x_offset = 1_spx + indentation * gsl::narrow<int>(level);
     const auto border = 3_spx;
-    const auto text_width = direct_write::text_out_columns_and_colours(
-        *context.m_group_text_format, context.dc, text, x_offset, border, rc, cr, {.enable_tab_columns = false});
+    const auto text_width = direct_write::text_out_columns_and_colours(*context.m_group_text_format, context.wnd,
+        context.dc, text, x_offset, border, rc, cr, {.enable_tab_columns = false});
 
     const auto line_height = 1_spx;
     const auto line_top = rc.top + wil::rect_height(rc) / 2 - line_height / 2;
@@ -303,8 +303,8 @@ void lv::DefaultRenderer::render_item(RendererContext context, size_t index, std
         rc_subitem.right = rc_subitem.left + sub_item.width;
 
         if (context.m_item_text_format)
-            direct_write::text_out_columns_and_colours(*context.m_item_text_format, context.dc, sub_item.text,
-                1_spx + (column_index == 0 ? indentation : 0), 3_spx, rc_subitem, cr_text,
+            direct_write::text_out_columns_and_colours(*context.m_item_text_format, context.wnd, context.dc,
+                sub_item.text, 1_spx + (column_index == 0 ? indentation : 0), 3_spx, rc_subitem, cr_text,
                 {.is_selected = b_selected,
                     .align = sub_item.alignment,
                     .enable_tab_columns = m_enable_item_tab_columns});

--- a/list_view/list_view_tooltip.cpp
+++ b/list_view/list_view_tooltip.cpp
@@ -180,7 +180,7 @@ void ListView::render_tooltip_text(HWND wnd, HDC dc, COLORREF colour) const
                 gsl::narrow_cast<float>(wil::rect_width(rc_text)) / scaling_factor,
                 gsl::narrow_cast<float>(wil::rect_height(rc_text)) / scaling_factor);
 
-            text_layout.render_with_transparent_background(dc, rc_text, colour, m_tooltip_text_left_offset);
+            text_layout.render_with_transparent_background(wnd, dc, rc_text, colour, m_tooltip_text_left_offset);
         }
         CATCH_LOG()
     }


### PR DESCRIPTION
This improves DirectWrite multi-monitor support by using monitor-specific rendering parameters.

Note that this means the top-level window containing the rendered text should invalidate itself and all children when moving between monitors.