### PR TITLE
Fix list view crash with grouping and header enabled

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -663,20 +663,16 @@ protected:
         }
     }
 
-    bool is_header_column_real(size_t index)
+    std::optional<size_t> get_real_column_index(size_t header_item_index) const
     {
-        if (m_have_indent_column)
-            return index != 0;
+        if (!m_have_indent_column)
+            return header_item_index;
 
-        return true;
-    }
+        if (m_have_indent_column && header_item_index == 0) {
+            return {};
+        }
 
-    size_t header_column_to_real_column(size_t index)
-    {
-        if (m_have_indent_column && index != pfc_infinite)
-            return index - 1;
-
-        return index;
+        return header_item_index - 1;
     }
 
     bool get_show_group_info_area() { return m_group_count ? m_show_group_info_area : false; }

--- a/list_view/list_view_header.cpp
+++ b/list_view/list_view_header.cpp
@@ -124,10 +124,10 @@ std::optional<LRESULT> ListView::on_wm_notify_header(LPNMHDR lpnm)
             if (m_header_theme)
                 GetThemeColor(m_header_theme.get(), HP_HEADERITEM, 0, TMT_TEXTCOLOR, &cr);
 
-            const auto index = header_column_to_real_column(lpcd->dwItemSpec);
+            const auto column_index = get_real_column_index(lpcd->dwItemSpec);
 
-            if (m_header_text_format) {
-                const auto& column = m_columns[index];
+            if (m_header_text_format && column_index) {
+                const auto& column = m_columns[*column_index];
 
                 direct_write::text_out_columns_and_colours(*m_header_text_format, get_wnd(), lpcd->hdc,
                     mmh::to_string_view(column.m_title), 0, 4_spx, lpcd->rc, cr,


### PR DESCRIPTION
https://github.com/reupen/columns_ui/issues/980

Resolves a regression from #160 that caused a crash when the list view was used with grouping and the header was enabled.