### PR TITLE
Invalidate items after hiding or showing list view header

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -205,7 +205,7 @@ public:
 
     [[nodiscard]] int _get_scroll_position() const { return m_scroll_position; }
 
-    void set_show_header(bool b_val);
+    void set_show_header(bool new_value);
     void set_show_tooltips(bool b_val);
     void set_limit_tooltips_to_clipped_items(bool b_val);
     void set_autosize(bool b_val);

--- a/list_view/list_view_header.cpp
+++ b/list_view/list_view_header.cpp
@@ -42,18 +42,23 @@ void ListView::set_header_window_theme() const
     SetWindowTheme(m_wnd_header, m_use_dark_mode ? L"DarkMode_ItemsView" : nullptr, nullptr);
 }
 
-void ListView::set_show_header(bool b_val)
+void ListView::set_show_header(bool new_value)
 {
-    if (b_val != m_show_header) {
-        m_show_header = b_val;
-        if (m_initialised) {
-            if (m_show_header)
-                create_header();
-            else
-                destroy_header();
-            on_size();
-        }
-    }
+    if (new_value == m_show_header)
+        return;
+
+    m_show_header = new_value;
+
+    if (!m_initialised)
+        return;
+
+    if (m_show_header)
+        create_header();
+    else
+        destroy_header();
+
+    invalidate_all();
+    on_size();
 }
 
 void ListView::reposition_header()


### PR DESCRIPTION
https://github.com/reupen/columns_ui/issues/982

This resolves a bug where the items in the list view weren't re-rendered if the header was hidden after the list view window had been created, and auto-sizing columns was turned off.