### PR TITLE
Fix occasional DirectWrite stack overflow

### DIFF
--- a/direct_write.h
+++ b/direct_write.h
@@ -89,14 +89,13 @@ public:
     void set_text_alignment(DWRITE_TEXT_ALIGNMENT value = DWRITE_TEXT_ALIGNMENT_LEADING) const;
     void set_paragraph_alignment(DWRITE_PARAGRAPH_ALIGNMENT value) const;
     void set_word_wrapping(DWRITE_WORD_WRAPPING value) const;
-    void enable_trimming_sign();
-    void disable_trimming_sign() const;
 
     [[nodiscard]] int get_minimum_height(std::wstring_view text = std::wstring_view(L"", 0)) const;
     [[nodiscard]] TextPosition measure_text_position(
-        std::wstring_view text, int height, float max_width = 65536.0f) const;
+        std::wstring_view text, int height, float max_width = 65536.0f, bool enable_ellipsis = false) const;
     [[nodiscard]] int measure_text_width(std::wstring_view text) const;
-    [[nodiscard]] TextLayout create_text_layout(std::wstring_view text, float max_width, float max_height) const;
+    [[nodiscard]] TextLayout create_text_layout(
+        std::wstring_view text, float max_width, float max_height, bool enable_ellipsis = false) const;
     [[nodiscard]] DWRITE_FONT_WEIGHT get_weight() const;
     [[nodiscard]] std::variant<DWRITE_FONT_STRETCH, float> get_stretch() const;
     [[nodiscard]] DWRITE_FONT_STYLE get_style() const;
@@ -106,7 +105,6 @@ private:
     wil::com_ptr_t<IDWriteFactory> m_factory;
     wil::com_ptr_t<IDWriteGdiInterop> m_gdi_interop;
     wil::com_ptr_t<IDWriteTextFormat> m_text_format;
-    wil::com_ptr_t<IDWriteInlineObject> m_trimming_sign;
     RenderingParams::Ptr m_rendering_params;
 };
 

--- a/list_view/list_view_tooltip.cpp
+++ b/list_view/list_view_tooltip.cpp
@@ -92,7 +92,6 @@ void ListView::calculate_tooltip_position(size_t item_index, size_t column_index
 
     try {
         m_items_text_format->set_text_alignment(direct_write::get_text_alignment(column.m_alignment));
-        m_items_text_format->enable_trimming_sign();
     }
     CATCH_LOG()
 
@@ -101,7 +100,7 @@ void ListView::calculate_tooltip_position(size_t item_index, size_t column_index
 
     const auto max_width = std::max(0.0f,
         static_cast<float>(column.m_display_size - 1_spx - 3_spx * 2) / direct_write::get_default_scaling_factor());
-    const auto metrics = m_items_text_format->measure_text_position(utf16_text, m_item_height, max_width);
+    const auto metrics = m_items_text_format->measure_text_position(utf16_text, m_item_height, max_width, true);
 
     m_tooltip_text_left_offset = metrics.left_remainder_dip;
 
@@ -175,7 +174,6 @@ void ListView::render_tooltip_text(HWND wnd, HDC dc, COLORREF colour) const
 
     if (m_items_text_format) {
         try {
-            m_items_text_format->disable_trimming_sign();
             m_items_text_format->set_text_alignment();
             const auto scaling_factor = direct_write::get_default_scaling_factor();
 


### PR DESCRIPTION
This resolves the DirectWrite crash mentioned in https://blog.yuo.be/2024/12/07/the-unresolved-crash-releasing-an-idwritetextformat/.

This was traced to calling `IDWriteFactory::CreateEllipsisTrimmingSign()` with a text format, and then passing the returned `IDWriteInlineObject` to `IDWriteTextFormat::SetTrimming()` for the same text format. Evidently, this was causing some recursion when releasing the text format, which sometimes caused a stack overflow.

The fix is to simply call `IDWriteTextFormat::SetTrimming()` on the `IDWriteTextLayout` object  instead (`IDWriteTextLayout` inherits from `IDWriteTextFormat`). From testing, this breaks the recursion. Doing this on the text layout is also more logical and convenient.