### PR TITLE
Add additional subclassed window buffered painting helpers

### DIFF
--- a/gdi.cpp
+++ b/gdi.cpp
@@ -12,6 +12,29 @@ void paint_subclassed_window_with_buffering(HWND wnd, WNDPROC window_proc)
     CallWindowProc(window_proc, wnd, WM_PRINTCLIENT, reinterpret_cast<WPARAM>(buffered_dc.get()), PRF_CLIENT);
 }
 
+std::optional<LRESULT> handle_subclassed_window_buffered_painting(auto wnd_proc, auto wnd, auto msg, auto wp, auto lp)
+{
+    switch (msg) {
+    case WM_ERASEBKGND:
+        if (WindowFromDC(reinterpret_cast<HDC>(wp)) != wnd)
+            return {};
+
+        return FALSE;
+    case WM_PAINT:
+        uih::paint_subclassed_window_with_buffering(wnd, wnd_proc);
+        return 0;
+    }
+
+    return {};
+}
+
+void subclass_window_and_paint_with_buffering(HWND wnd)
+{
+    subclass_window(wnd, [](auto wnd_proc, auto wnd, auto msg, auto wp, auto lp) -> std::optional<LRESULT> {
+        return handle_subclassed_window_buffered_painting(wnd_proc, wnd, msg, wp, lp);
+    });
+}
+
 void draw_rect_outline(HDC dc, const RECT& rc, COLORREF colour, int width)
 {
     const wil::unique_hpen pen(CreatePen(PS_SOLID | PS_INSIDEFRAME, width, colour));

--- a/gdi.h
+++ b/gdi.h
@@ -52,6 +52,8 @@ private:
 };
 
 void paint_subclassed_window_with_buffering(HWND wnd, WNDPROC window_proc);
+std::optional<LRESULT> handle_subclassed_window_buffered_painting(auto wnd_proc, auto wnd, auto msg, auto wp, auto lp);
+void subclass_window_and_paint_with_buffering(HWND wnd);
 void draw_rect_outline(HDC dc, const RECT& rc, COLORREF colour, int width);
 
 } // namespace uih

--- a/list_view/list_view_tooltip.cpp
+++ b/list_view/list_view_tooltip.cpp
@@ -33,7 +33,7 @@ void ListView::create_tooltip(/*size_t index, size_t column, */ const char* str)
     if (IsThemeActive() && IsAppThemed())
         m_tooltip_theme.reset(OpenThemeData(m_wnd_tooltip, L"Tooltip"));
 
-    uih::subclass_window(m_wnd_tooltip, [this](auto wnd, auto msg, auto wp, auto lp) {
+    uih::subclass_window(m_wnd_tooltip, [this](auto _, auto wnd, auto msg, auto wp, auto lp) {
         if (msg == WM_THEMECHANGED && IsThemeActive() && IsAppThemed())
             m_tooltip_theme.reset(OpenThemeData(m_wnd_tooltip, L"Tooltip"));
 

--- a/win32_helpers.cpp
+++ b/win32_helpers.cpp
@@ -548,7 +548,7 @@ void enhance_edit_control(HWND wnd)
     };
 
     subclass_window(
-        wnd, [send_backspace, delete_text](HWND wnd, UINT msg, WPARAM wp, LPARAM lp) -> std::optional<LRESULT> {
+        wnd, [send_backspace, delete_text](auto _, HWND wnd, UINT msg, WPARAM wp, LPARAM lp) -> std::optional<LRESULT> {
             switch (msg) {
             case WM_KEYDOWN:
                 // If Autocomplete is enabled, it processes Ctrl+Backspace here

--- a/window_subclasser.cpp
+++ b/window_subclasser.cpp
@@ -6,7 +6,8 @@ namespace {
 
 struct WindowState {
     WNDPROC wnd_proc{};
-    std::function<std::optional<LRESULT>(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> message_handler;
+    std::function<std::optional<LRESULT>(WNDPROC window_proc, HWND wnd, UINT msg, WPARAM wp, LPARAM lp)>
+        message_handler;
 };
 
 std::unordered_map<HWND, WindowState> state_map;
@@ -16,7 +17,7 @@ LRESULT __stdcall handle_subclassed_window_message(HWND wnd, UINT msg, WPARAM wp
     const auto& state = state_map.at(wnd);
     const auto wnd_proc = state.wnd_proc;
 
-    if (const auto result = state.message_handler(wnd, msg, wp, lp))
+    if (const auto result = state.message_handler(wnd_proc, wnd, msg, wp, lp))
         return *result;
 
     if (msg == WM_NCDESTROY)
@@ -27,8 +28,8 @@ LRESULT __stdcall handle_subclassed_window_message(HWND wnd, UINT msg, WPARAM wp
 
 } // namespace
 
-void subclass_window(
-    HWND wnd, std::function<std::optional<LRESULT>(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> message_handler)
+void subclass_window(HWND wnd,
+    std::function<std::optional<LRESULT>(WNDPROC wnd_proc, HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> message_handler)
 {
     const auto wnd_proc = SubclassWindow(wnd, handle_subclassed_window_message);
     state_map[wnd] = WindowState{wnd_proc, std::move(message_handler)};

--- a/window_subclasser.h
+++ b/window_subclasser.h
@@ -2,7 +2,7 @@
 
 namespace uih {
 
-void subclass_window(
-    HWND wnd, std::function<std::optional<LRESULT>(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> message_handler);
+void subclass_window(HWND wnd,
+    std::function<std::optional<LRESULT>(WNDPROC wnd_proc, HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> message_handler);
 
-}
+} // namespace uih


### PR DESCRIPTION
This adds some additional helpers for subclassing windows and painting them with buffering (used to fix flickering in common controls).