### PR TITLE
Mark Win32 callback functions and COM interface methods as noexcept

### DIFF
--- a/container_window.cpp
+++ b/container_window.cpp
@@ -43,7 +43,7 @@ void ContainerWindow::destroy()
     }
 }
 
-LRESULT ContainerWindow::s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT ContainerWindow::s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     ContainerWindow* p_this = nullptr;
 

--- a/container_window.h
+++ b/container_window.h
@@ -82,7 +82,7 @@ public:
     HWND get_wnd() const { return m_wnd; }
 
 private:
-    static LRESULT WINAPI s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    static LRESULT WINAPI s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
 
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
     void register_class();

--- a/dialog.cpp
+++ b/dialog.cpp
@@ -8,7 +8,7 @@ struct DialogBoxData {
     std::shared_ptr<DialogBoxData> self;
 };
 
-INT_PTR WINAPI on_dialog_box_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+INT_PTR WINAPI on_dialog_box_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     DialogBoxData* data{};
     if (msg == WM_INITDIALOG) {

--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -804,7 +804,7 @@ private:
     void remove_items_in_internal_state(const pfc::bit_array& mask);
     void calculate_item_positions(size_t index_start = 0);
 
-    static LRESULT WINAPI s_on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    static LRESULT WINAPI s_on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
     LRESULT on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
     void create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column);
@@ -815,7 +815,7 @@ private:
 
     void on_search_string_change(WCHAR c);
 
-    static LRESULT WINAPI s_on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    static LRESULT WINAPI s_on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
     LRESULT on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
     void update_search_box_hot_status(const POINT& pt);
 

--- a/list_view/list_view_inline_edit.cpp
+++ b/list_view/list_view_inline_edit.cpp
@@ -89,7 +89,7 @@ void ListView::activate_inline_editing(size_t index, size_t column)
     activate_inline_editing(pfc::list_single_ref_t<size_t>(index), column);
 }
 
-LRESULT WINAPI ListView::s_on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI ListView::s_on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     ListView* p_this;
     LRESULT rv;

--- a/list_view/list_view_search.cpp
+++ b/list_view/list_view_search.cpp
@@ -108,7 +108,7 @@ int ListView::get_search_box_height() const
     return ret;
 }
 
-LRESULT WINAPI ListView::s_on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI ListView::s_on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     ListView* p_this;
     LRESULT rv;

--- a/message_hook.cpp
+++ b/message_hook.cpp
@@ -32,27 +32,27 @@ LRESULT CALLBACK g_on_hooked_message(uih::MessageHookType p_type, int code, WPAR
     return b_call_next ? CallNextHookEx(nullptr, code, wp, lp) : p_type != MessageHookType::type_get_message ? TRUE : 0;
 }
 
-LRESULT CALLBACK g_keyboard_proc(int code, WPARAM wp, LPARAM lp)
+LRESULT CALLBACK g_keyboard_proc(int code, WPARAM wp, LPARAM lp) noexcept
 {
     return g_on_hooked_message(MessageHookType::type_keyboard, code, wp, lp);
 }
 
-LRESULT CALLBACK g_getmsg_proc(int code, WPARAM wp, LPARAM lp)
+LRESULT CALLBACK g_getmsg_proc(int code, WPARAM wp, LPARAM lp) noexcept
 {
     return g_on_hooked_message(MessageHookType::type_get_message, code, wp, lp);
 }
 
-LRESULT CALLBACK g_message_proc(int code, WPARAM wp, LPARAM lp)
+LRESULT CALLBACK g_message_proc(int code, WPARAM wp, LPARAM lp) noexcept
 {
     return g_on_hooked_message(MessageHookType::type_message_filter, code, wp, lp);
 }
 
-LRESULT CALLBACK g_mouse_proc(int code, WPARAM wp, LPARAM lp)
+LRESULT CALLBACK g_mouse_proc(int code, WPARAM wp, LPARAM lp) noexcept
 {
     return g_on_hooked_message(MessageHookType::type_mouse, code, wp, lp);
 }
 
-LRESULT CALLBACK g_mouse_low_level_proc(int code, WPARAM wp, LPARAM lp)
+LRESULT CALLBACK g_mouse_low_level_proc(int code, WPARAM wp, LPARAM lp) noexcept
 {
     return g_on_hooked_message(MessageHookType::type_mouse_low_level, code, wp, lp);
 }

--- a/ole.cpp
+++ b/ole.cpp
@@ -177,7 +177,7 @@ HRESULT do_drag_drop(HWND wnd, WPARAM initialKeyState, IDataObject* pDataObject,
     return SHDoDragDrop(wnd, pDataObject, pDropSource, dwEffect, pdwEffect);
 }
 
-HRESULT STDMETHODCALLTYPE IDropSourceGeneric::QueryInterface(REFIID iid, void** ppvObject)
+HRESULT STDMETHODCALLTYPE IDropSourceGeneric::QueryInterface(REFIID iid, void** ppvObject) noexcept
 {
     if (ppvObject == nullptr)
         return E_INVALIDARG;
@@ -197,11 +197,11 @@ HRESULT STDMETHODCALLTYPE IDropSourceGeneric::QueryInterface(REFIID iid, void** 
     }
     return E_NOINTERFACE;
 }
-ULONG STDMETHODCALLTYPE IDropSourceGeneric::AddRef()
+ULONG STDMETHODCALLTYPE IDropSourceGeneric::AddRef() noexcept
 {
     return InterlockedIncrement(&m_refcount);
 }
-ULONG STDMETHODCALLTYPE IDropSourceGeneric::Release()
+ULONG STDMETHODCALLTYPE IDropSourceGeneric::Release() noexcept
 {
     LONG rv = InterlockedDecrement(&m_refcount);
     if (!rv) {
@@ -210,7 +210,7 @@ ULONG STDMETHODCALLTYPE IDropSourceGeneric::Release()
     return rv;
 }
 
-HRESULT STDMETHODCALLTYPE IDropSourceGeneric::QueryContinueDrag(BOOL fEscapePressed, DWORD grfKeyState)
+HRESULT STDMETHODCALLTYPE IDropSourceGeneric::QueryContinueDrag(BOOL fEscapePressed, DWORD grfKeyState) noexcept
 {
     if (fEscapePressed || ((m_initial_key_state & MK_LBUTTON) && (grfKeyState & MK_RBUTTON))) {
         return DRAGDROP_S_CANCEL;
@@ -223,7 +223,7 @@ HRESULT STDMETHODCALLTYPE IDropSourceGeneric::QueryContinueDrag(BOOL fEscapePres
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE IDropSourceGeneric::GiveFeedback(DWORD dwEffect)
+HRESULT STDMETHODCALLTYPE IDropSourceGeneric::GiveFeedback(DWORD dwEffect) noexcept
 {
     HWND wnd_drag = nullptr;
     BOOL isShowingLayered = FALSE;

--- a/ole.h
+++ b/ole.h
@@ -15,11 +15,11 @@ HRESULT do_drag_drop(HWND wnd, WPARAM initialKeyState, IDataObject* pDataObject,
 
 class IDropSourceGeneric : public IDropSource {
 public:
-    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** ppvObject) override;
-    ULONG STDMETHODCALLTYPE AddRef() override;
-    ULONG STDMETHODCALLTYPE Release() override;
-    HRESULT STDMETHODCALLTYPE QueryContinueDrag(BOOL fEscapePressed, DWORD grfKeyState) override;
-    HRESULT STDMETHODCALLTYPE GiveFeedback(DWORD dwEffect) override;
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** ppvObject) noexcept override;
+    ULONG STDMETHODCALLTYPE AddRef() noexcept override;
+    ULONG STDMETHODCALLTYPE Release() noexcept override;
+    HRESULT STDMETHODCALLTYPE QueryContinueDrag(BOOL fEscapePressed, DWORD grfKeyState) noexcept override;
+    HRESULT STDMETHODCALLTYPE GiveFeedback(DWORD dwEffect) noexcept override;
     IDropSourceGeneric(HWND wnd, IDataObject* pDataObj, DWORD initial_key_state, bool b_allowdropdescriptiontext = true,
         SHDRAGIMAGE* lpsdi = nullptr); // careful, some fb2k versions have broken IDataObject
 private:

--- a/ole/data_object.cpp
+++ b/ole/data_object.cpp
@@ -49,7 +49,7 @@ CDataObject::~CDataObject()
         ReleaseStgMedium(&m_data_entries[i].sm);
 }
 
-STDMETHODIMP CDataObject::QueryInterface(REFIID riid, LPVOID* ppvOut)
+HRESULT STDMETHODCALLTYPE CDataObject::QueryInterface(REFIID riid, LPVOID* ppvOut) noexcept
 {
     *ppvOut = nullptr;
 
@@ -71,12 +71,12 @@ STDMETHODIMP CDataObject::QueryInterface(REFIID riid, LPVOID* ppvOut)
     return E_NOINTERFACE;
 }
 
-STDMETHODIMP_(ULONG) CDataObject::AddRef()
+ULONG STDMETHODCALLTYPE CDataObject::AddRef() noexcept
 {
     return ++m_cRefCount;
 }
 
-STDMETHODIMP_(ULONG) CDataObject::Release()
+ULONG STDMETHODCALLTYPE CDataObject::Release() noexcept
 {
     if (--m_cRefCount == 0) {
         delete this;
@@ -112,7 +112,7 @@ HRESULT CDataObject::_GetStgMediumAddRef(size_t index, STGMEDIUM* pstgmOut)
     return hres;
 }
 
-STDMETHODIMP CDataObject::GetData(LPFORMATETC pFE, LPSTGMEDIUM pSM)
+HRESULT STDMETHODCALLTYPE CDataObject::GetData(LPFORMATETC pFE, LPSTGMEDIUM pSM) noexcept
 {
     if (pFE == nullptr || pSM == nullptr)
         return E_INVALIDARG;
@@ -134,7 +134,7 @@ STDMETHODIMP CDataObject::GetData(LPFORMATETC pFE, LPSTGMEDIUM pSM)
     return hr;
 }
 
-STDMETHODIMP CDataObject::GetDataHere(LPFORMATETC pFE, LPSTGMEDIUM pSM)
+HRESULT STDMETHODCALLTYPE CDataObject::GetDataHere(LPFORMATETC pFE, LPSTGMEDIUM pSM) noexcept
 {
     return E_NOTIMPL;
 }
@@ -160,18 +160,18 @@ HRESULT CDataObject::_FindFormatEtc(LPFORMATETC pFE, size_t& index, bool b_check
     return DV_E_FORMATETC;
 }
 
-STDMETHODIMP CDataObject::QueryGetData(LPFORMATETC pFE)
+HRESULT STDMETHODCALLTYPE CDataObject::QueryGetData(LPFORMATETC pFE) noexcept
 {
     size_t index;
     return _FindFormatEtc(pFE, index, true);
 }
 
-STDMETHODIMP CDataObject::GetCanonicalFormatEtc(LPFORMATETC pFE1, LPFORMATETC pFE2)
+HRESULT STDMETHODCALLTYPE CDataObject::GetCanonicalFormatEtc(LPFORMATETC pFE1, LPFORMATETC pFE2) noexcept
 {
     return DATA_S_SAMEFORMATETC;
 }
 
-STDMETHODIMP CDataObject::SetData(LPFORMATETC pFE, LPSTGMEDIUM pSM, BOOL fRelease)
+HRESULT STDMETHODCALLTYPE CDataObject::SetData(LPFORMATETC pFE, LPSTGMEDIUM pSM, BOOL fRelease) noexcept
 {
     if (pFE->ptd != nullptr)
         return DV_E_DVTARGETDEVICE;
@@ -208,7 +208,7 @@ STDMETHODIMP CDataObject::SetData(LPFORMATETC pFE, LPSTGMEDIUM pSM, BOOL fReleas
     return S_OK;
 }
 
-STDMETHODIMP CDataObject::EnumFormatEtc(DWORD dwDir, LPENUMFORMATETC* ppEnum)
+HRESULT STDMETHODCALLTYPE CDataObject::EnumFormatEtc(DWORD dwDir, LPENUMFORMATETC* ppEnum) noexcept
 {
     // console::formatter() << "EnumFormatEtc";
 
@@ -238,17 +238,18 @@ STDMETHODIMP CDataObject::EnumFormatEtc(DWORD dwDir, LPENUMFORMATETC* ppEnum)
     return E_OUTOFMEMORY;
 }
 
-STDMETHODIMP CDataObject::DAdvise(LPFORMATETC pFE, DWORD advf, LPADVISESINK pAdvSink, LPDWORD pdwConnection)
+HRESULT STDMETHODCALLTYPE CDataObject::DAdvise(
+    LPFORMATETC pFE, DWORD advf, LPADVISESINK pAdvSink, LPDWORD pdwConnection) noexcept
 {
     return E_NOTIMPL;
 }
 
-STDMETHODIMP CDataObject::DUnadvise(DWORD dwConnection)
+HRESULT STDMETHODCALLTYPE CDataObject::DUnadvise(DWORD dwConnection) noexcept
 {
     return E_NOTIMPL;
 }
 
-STDMETHODIMP CDataObject::EnumDAdvise(LPENUMSTATDATA* ppenumAdvise)
+HRESULT STDMETHODCALLTYPE CDataObject::EnumDAdvise(LPENUMSTATDATA* ppenumAdvise) noexcept
 {
     return OLE_E_ADVISENOTSUPPORTED;
 }

--- a/ole/data_object.h
+++ b/ole/data_object.h
@@ -28,20 +28,20 @@ public:
     ~CDataObject();
 
     // IUnknown members that delegate to m_pUnkOuter.
-    STDMETHOD(QueryInterface)(REFIID, LPVOID*);
-    STDMETHOD_(ULONG, AddRef)();
-    STDMETHOD_(ULONG, Release)();
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID, LPVOID*) noexcept override;
+    ULONG STDMETHODCALLTYPE AddRef() noexcept override;
+    ULONG STDMETHODCALLTYPE Release() noexcept override;
 
     /* IDataObject methods */
-    STDMETHOD(GetData)(LPFORMATETC, LPSTGMEDIUM);
-    STDMETHOD(GetDataHere)(LPFORMATETC, LPSTGMEDIUM);
-    STDMETHOD(QueryGetData)(LPFORMATETC);
-    STDMETHOD(GetCanonicalFormatEtc)(LPFORMATETC, LPFORMATETC);
-    STDMETHOD(SetData)(LPFORMATETC, LPSTGMEDIUM, BOOL);
-    STDMETHOD(EnumFormatEtc)(DWORD, LPENUMFORMATETC*);
-    STDMETHOD(DAdvise)(FORMATETC*, DWORD, LPADVISESINK, LPDWORD);
-    STDMETHOD(DUnadvise)(DWORD);
-    STDMETHOD(EnumDAdvise)(LPENUMSTATDATA*);
+    HRESULT STDMETHODCALLTYPE GetData(LPFORMATETC, LPSTGMEDIUM) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetDataHere(LPFORMATETC, LPSTGMEDIUM) noexcept override;
+    HRESULT STDMETHODCALLTYPE QueryGetData(LPFORMATETC) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetCanonicalFormatEtc(LPFORMATETC, LPFORMATETC) noexcept override;
+    HRESULT STDMETHODCALLTYPE SetData(LPFORMATETC, LPSTGMEDIUM, BOOL) noexcept override;
+    HRESULT STDMETHODCALLTYPE EnumFormatEtc(DWORD, LPENUMFORMATETC*) noexcept override;
+    HRESULT STDMETHODCALLTYPE DAdvise(FORMATETC*, DWORD, LPADVISESINK, LPDWORD) noexcept override;
+    HRESULT STDMETHODCALLTYPE DUnadvise(DWORD) noexcept override;
+    HRESULT STDMETHODCALLTYPE EnumDAdvise(LPENUMSTATDATA*) noexcept override;
 
 private:
     HRESULT _FindFormatEtc(LPFORMATETC lpfe, size_t& index, bool b_checkTymed);

--- a/ole/enum_format_etc.cpp
+++ b/ole/enum_format_etc.cpp
@@ -42,7 +42,7 @@ CEnumFormatEtc::~CEnumFormatEtc()
     delete[] m_pStrFE;
 }
 
-STDMETHODIMP CEnumFormatEtc::QueryInterface(REFIID riid, LPVOID* ppvOut)
+HRESULT STDMETHODCALLTYPE CEnumFormatEtc::QueryInterface(REFIID riid, LPVOID* ppvOut) noexcept
 {
     *ppvOut = nullptr;
 
@@ -64,12 +64,12 @@ STDMETHODIMP CEnumFormatEtc::QueryInterface(REFIID riid, LPVOID* ppvOut)
     return E_NOINTERFACE;
 }
 
-STDMETHODIMP_(ULONG) CEnumFormatEtc::AddRef()
+ULONG STDMETHODCALLTYPE CEnumFormatEtc::AddRef() noexcept
 {
     return ++m_cRefCount;
 }
 
-STDMETHODIMP_(ULONG) CEnumFormatEtc::Release()
+ULONG STDMETHODCALLTYPE CEnumFormatEtc::Release() noexcept
 {
     if (--m_cRefCount == 0) {
         delete this;
@@ -79,7 +79,7 @@ STDMETHODIMP_(ULONG) CEnumFormatEtc::Release()
     return m_cRefCount;
 }
 
-STDMETHODIMP CEnumFormatEtc::Next(ULONG celt, LPFORMATETC pFE, ULONG* puFetched)
+HRESULT STDMETHODCALLTYPE CEnumFormatEtc::Next(ULONG celt, LPFORMATETC pFE, ULONG* puFetched) noexcept
 {
     ULONG cReturn = 0L;
 
@@ -104,7 +104,7 @@ STDMETHODIMP CEnumFormatEtc::Next(ULONG celt, LPFORMATETC pFE, ULONG* puFetched)
     return S_OK;
 }
 
-STDMETHODIMP CEnumFormatEtc::Skip(ULONG celt)
+HRESULT STDMETHODCALLTYPE CEnumFormatEtc::Skip(ULONG celt) noexcept
 {
     if ((m_iCur + celt) >= m_cItems)
         return S_FALSE;
@@ -114,14 +114,14 @@ STDMETHODIMP CEnumFormatEtc::Skip(ULONG celt)
     return S_OK;
 }
 
-STDMETHODIMP CEnumFormatEtc::Reset()
+HRESULT STDMETHODCALLTYPE CEnumFormatEtc::Reset() noexcept
 {
     m_iCur = 0;
 
     return S_OK;
 }
 
-STDMETHODIMP CEnumFormatEtc::Clone(IEnumFORMATETC** ppCloneEnumFormatEtc)
+HRESULT STDMETHODCALLTYPE CEnumFormatEtc::Clone(IEnumFORMATETC** ppCloneEnumFormatEtc) noexcept
 {
     CEnumFormatEtc* newEnum;
 

--- a/ole/enum_format_etc.h
+++ b/ole/enum_format_etc.h
@@ -28,15 +28,15 @@ public:
     // BOOL FInit(HWND);
 
     // IUnknown members
-    STDMETHOD(QueryInterface)(REFIID, LPVOID*);
-    STDMETHOD_(ULONG, AddRef)();
-    STDMETHOD_(ULONG, Release)();
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID, LPVOID*) noexcept override;
+    ULONG STDMETHODCALLTYPE AddRef() noexcept override;
+    ULONG STDMETHODCALLTYPE Release() noexcept override;
 
     // IEnumFORMATETC members
-    STDMETHOD(Next)(ULONG, LPFORMATETC, ULONG*);
-    STDMETHOD(Skip)(ULONG);
-    STDMETHOD(Reset)();
-    STDMETHOD(Clone)(IEnumFORMATETC**);
+    HRESULT STDMETHODCALLTYPE Next(ULONG, LPFORMATETC, ULONG*) noexcept override;
+    HRESULT STDMETHODCALLTYPE Skip(ULONG) noexcept override;
+    HRESULT STDMETHODCALLTYPE Reset() noexcept override;
+    HRESULT STDMETHODCALLTYPE Clone(IEnumFORMATETC**) noexcept override;
 
 private:
     DWORD m_cRefCount;

--- a/window_subclasser.cpp
+++ b/window_subclasser.cpp
@@ -12,7 +12,7 @@ struct WindowState {
 
 std::unordered_map<HWND, WindowState> state_map;
 
-LRESULT __stdcall handle_subclassed_window_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT __stdcall handle_subclassed_window_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     const auto& state = state_map.at(wnd);
     const auto wnd_proc = state.wnd_proc;


### PR DESCRIPTION
This marks various callback functions passed to the Win32 API, such as window procedures, and and COM interface methods, as noexcept.

This is as they aren't allowed to throw C++ exceptions. `noexcept` will result in `std::terminate` being called if that happens.