### PR TITLE
Work around DirectWrite not rendering trailing whitespace

### DIFF
--- a/direct_write_text_out.cpp
+++ b/direct_write_text_out.cpp
@@ -19,6 +19,11 @@ int text_out_colours(const TextFormat& text_format, HWND wnd, HDC dc, std::strin
         ? process_colour_codes(mmh::to_utf16(text), selected)
         : std::tuple(mmh::to_utf16(text), std::vector<ColouredTextSegment>{});
 
+    // Work around DirectWrite not rendering trailing whitespace
+    // for centre- and right-aligned text
+    if (align != ALIGN_LEFT)
+        render_text.push_back(L'\u200b');
+
     text_format.set_text_alignment(get_text_alignment(align));
 
     try {

--- a/list_view/list_view_tooltip.cpp
+++ b/list_view/list_view_tooltip.cpp
@@ -95,11 +95,17 @@ void ListView::calculate_tooltip_position(size_t item_index, size_t column_index
     }
     CATCH_LOG()
 
-    const auto utf16_text = mmh::to_utf16(text);
+    auto utf16_text = mmh::to_utf16(text);
     const auto text_width = m_items_text_format->measure_text_width(utf16_text);
 
     const auto max_width = std::max(0.0f,
         static_cast<float>(column.m_display_size - 1_spx - 3_spx * 2) / direct_write::get_default_scaling_factor());
+
+    // Work around DirectWrite not rendering trailing whitespace
+    // for centre- and right-aligned text
+    if (column.m_alignment != ALIGN_LEFT)
+        utf16_text.push_back(L'\u200b');
+
     const auto metrics = m_items_text_format->measure_text_position(utf16_text, m_item_height, max_width, true);
 
     m_tooltip_text_left_offset = metrics.left_remainder_dip;


### PR DESCRIPTION
This adds a somewhat crude workaround for DirectWrite not rendering trailing whitespace for centre- and right-aligned text.

The workaround is to add a zero-width space at the end of the string. (A zero-width space is not considered a whitespace character.)

Unfortunately, I've found no other solution for this problem (other than using custom text layout code, which is not a particularly enticing prospect).

The workaround is only useful for single-line text, and is part of the `text_out_columns_and_colours()` helper (rather than the underlying DirectWrite helpers, as it doesn't make sense to do this there).