### PR TITLE
Improve recovery when DirectWrite font becomes invalid

### DIFF
--- a/direct_write.cpp
+++ b/direct_write.cpp
@@ -1071,6 +1071,11 @@ std::vector<FontFamily> Context::get_font_families() const
     return families;
 }
 
+bool should_recreate_text_format(HRESULT hr)
+{
+    return hr == DWRITE_E_FILENOTFOUND || hr == 0xFFFFFC18L;
+}
+
 std::wstring get_localised_string(const wil::com_ptr<IDWriteLocalizedStrings>& localised_strings)
 {
     std::array<wchar_t, LOCALE_NAME_MAX_LENGTH> locale_name;

--- a/direct_write.h
+++ b/direct_write.h
@@ -206,6 +206,8 @@ private:
     wil::com_ptr<IDWriteTypography> m_default_typography;
 };
 
+bool should_recreate_text_format(HRESULT hr);
+
 std::wstring get_localised_string(const wil::com_ptr<IDWriteLocalizedStrings>& localised_strings);
 float get_default_scaling_factor();
 

--- a/direct_write_text_out.cpp
+++ b/direct_write_text_out.cpp
@@ -26,26 +26,21 @@ int text_out_colours(const TextFormat& text_format, HWND wnd, HDC dc, std::strin
 
     text_format.set_text_alignment(get_text_alignment(align));
 
-    try {
-        const auto scaling_factor = get_default_scaling_factor();
+    const auto scaling_factor = get_default_scaling_factor();
 
-        const auto layout = text_format.create_text_layout(render_text,
-            gsl::narrow_cast<float>(wil::rect_width(rect)) / scaling_factor,
+    const auto layout
+        = text_format.create_text_layout(render_text, gsl::narrow_cast<float>(wil::rect_width(rect)) / scaling_factor,
             gsl::narrow_cast<float>(wil::rect_height(rect)) / scaling_factor, enable_ellipsis);
 
-        for (auto& [colour, start_character, character_count] : segments) {
-            layout.set_colour(colour, {gsl::narrow<uint32_t>(start_character), gsl::narrow<uint32_t>(character_count)});
-        }
-
-        const auto metrics = layout.get_metrics();
-
-        layout.render_with_transparent_background(wnd, dc, rect, default_color);
-
-        return gsl::narrow_cast<int>(metrics.width * scaling_factor + 1);
+    for (auto& [colour, start_character, character_count] : segments) {
+        layout.set_colour(colour, {gsl::narrow<uint32_t>(start_character), gsl::narrow<uint32_t>(character_count)});
     }
-    CATCH_LOG()
 
-    return 0;
+    const auto metrics = layout.get_metrics();
+
+    layout.render_with_transparent_background(wnd, dc, rect, default_color);
+
+    return gsl::narrow_cast<int>(metrics.width * scaling_factor + 1);
 }
 
 } // namespace

--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -21,8 +21,6 @@ public:
     static constexpr short IDC_INLINEEDIT = 667;
     static constexpr short IDC_SEARCHBOX = 668;
 
-    static constexpr unsigned MSG_KILL_INLINE_EDIT = WM_USER + 3;
-
     enum {
         TIMER_SCROLL_UP = 1001,
         TIMER_SCROLL_DOWN = 1002,
@@ -699,6 +697,11 @@ protected:
     void focus_search_box();
 
 private:
+    static constexpr unsigned MSG_KILL_INLINE_EDIT = WM_USER + 3;
+    static constexpr unsigned MSG_REQUEST_NEW_ITEMS_TEXT_FORMAT = WM_USER + 4;
+    static constexpr unsigned MSG_REQUEST_NEW_HEADER_TEXT_FORMAT = WM_USER + 5;
+    static constexpr unsigned MSG_REQUEST_NEW_GROUP_TEXT_FORMAT = WM_USER + 6;
+
     struct ItemsFontConfig {
         wil::com_ptr<IDWriteTextFormat> text_format;
         LOGFONT log_font{};
@@ -755,6 +758,10 @@ private:
 
     virtual Item* storage_create_item() { return new Item; }
     virtual Group* storage_create_group() { return new Group; }
+
+    virtual void recreate_items_text_format();
+    virtual void recreate_header_text_format();
+    virtual void recreate_group_text_format();
 
     virtual bool render_drag_image(LPSHDRAGIMAGE lpsdi);
     virtual wil::unique_hicon get_drag_image_icon() { return nullptr; }

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -705,4 +705,27 @@ void ListView::set_edge_style(uint32_t b_val)
         SetWindowPos(get_wnd(), nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_FRAMECHANGED);
     }
 }
+
+void ListView::recreate_items_text_format()
+{
+    if (m_direct_write_context && m_items_log_font) {
+        set_font(
+            m_direct_write_context->create_text_format_with_fallback(*m_items_log_font), LOGFONT{*m_items_log_font});
+    }
+}
+
+void ListView::recreate_header_text_format()
+{
+    if (m_direct_write_context && m_header_log_font) {
+        set_header_font(
+            m_direct_write_context->create_text_format_with_fallback(*m_header_log_font), LOGFONT{*m_header_log_font});
+    }
+}
+
+void ListView::recreate_group_text_format()
+{
+    if (m_direct_write_context && m_items_log_font) {
+        set_group_font(m_direct_write_context->create_text_format_with_fallback(*m_items_log_font));
+    }
+}
 } // namespace uih

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -750,6 +750,15 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         exit_inline_edit();
         m_inline_edit_prevent_kill = false;
         return 0;
+    case MSG_REQUEST_NEW_ITEMS_TEXT_FORMAT:
+        recreate_items_text_format();
+        return 0;
+    case MSG_REQUEST_NEW_HEADER_TEXT_FORMAT:
+        recreate_header_text_format();
+        return 0;
+    case MSG_REQUEST_NEW_GROUP_TEXT_FORMAT:
+        recreate_group_text_format();
+        return 0;
     case WM_CONTEXTMENU: {
         POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
         const auto from_keyboard = pt.x == -1 && pt.y == -1;


### PR DESCRIPTION
This improves recovery when a font being used by a text format is deleted or modified, and DirectWrite starts returning errors.

This is done by letter some exceptions bubble up further so they can be handled more appropriately.