### PR TITLE
Fix DirectWrite colour effects not being applied to ellipses

### DIFF
--- a/direct_write.cpp
+++ b/direct_write.cpp
@@ -274,6 +274,23 @@ public:
         IDWriteInlineObject* inlineObject, BOOL isSideways, BOOL isRightToLeft,
         IUnknown* clientDrawingEffect) noexcept override
     {
+        wil::com_ptr<ColourEffect> colour_effect;
+        std::optional<COLORREF> previous_default_colour;
+
+        if (clientDrawingEffect) {
+            colour_effect = wil::try_com_query<ColourEffect>(clientDrawingEffect);
+        }
+
+        if (colour_effect) {
+            previous_default_colour = m_default_colour;
+            m_default_colour = colour_effect->GetColour();
+        }
+
+        auto _ = gsl::finally([&] {
+            if (previous_default_colour)
+                m_default_colour = *previous_default_colour;
+        });
+
         return inlineObject->Draw(
             clientDrawingContext, this, originX, originY, isSideways, isRightToLeft, clientDrawingEffect);
     }


### PR DESCRIPTION
This works around a problem with the inline object created by `IDWriteFactory::CreateEllipsisTrimmingSign()` seemingly does nothing with the `clientDrawingEffect` passed to it, causing the ellipsis to be rendered using the wrong colour when a colour drawing effect was active.

(This change is only relevant for the custom GDI renderer. Interestingly the renderer used by Direct2D does not have this problem.)