### PR TITLE
Sort emoji font family names

### DIFF
--- a/direct_write.cpp
+++ b/direct_write.cpp
@@ -1167,6 +1167,10 @@ std::vector<std::wstring> Context::get_emoji_font_families() const
         emoji_family_names.emplace_back(get_localised_string(family_names));
     }
 
+    mmh::in_place_sort(
+        emoji_family_names, [](auto&& left, auto&& right) { return StrCmpLogicalW(left.c_str(), right.c_str()); },
+        false);
+
     return emoji_family_names;
 }
 


### PR DESCRIPTION
This makes `direct_write::Context::get_emoji_font_families()` sort the returned font family names.