### PR TITLE
Expose emoji IDWriteFontFallback object

### DIFF
--- a/direct_write.h
+++ b/direct_write.h
@@ -114,7 +114,6 @@ public:
     void set_text_alignment(DWRITE_TEXT_ALIGNMENT value = DWRITE_TEXT_ALIGNMENT_LEADING) const;
     void set_paragraph_alignment(DWRITE_PARAGRAPH_ALIGNMENT value) const;
     void set_word_wrapping(DWRITE_WORD_WRAPPING value) const;
-    void set_emoji_font_selection_config(std::optional<EmojiFontSelectionConfig> emoji_font_selection_config);
 
     [[nodiscard]] int get_minimum_height(std::wstring_view text = std::wstring_view(L"", 0)) const;
     [[nodiscard]] TextPosition measure_text_position(
@@ -132,7 +131,6 @@ private:
     wil::com_ptr<IDWriteGdiInterop> m_gdi_interop;
     wil::com_ptr<IDWriteTextFormat> m_text_format;
     RenderingParams::Ptr m_rendering_params;
-    wil::com_ptr<IDWriteFontFallback> m_font_fallback;
 };
 
 struct Font {
@@ -213,6 +211,9 @@ public:
     TextFormat wrap_text_format(wil::com_ptr<IDWriteTextFormat> text_format,
         DWRITE_RENDERING_MODE rendering_mode = DWRITE_RENDERING_MODE_DEFAULT, bool force_greyscale_antialiasing = false,
         bool use_colour_glyphs = true, bool set_defaults = true);
+
+    wil::com_ptr<IDWriteFontFallback> create_emoji_font_fallback(
+        const EmojiFontSelectionConfig& emoji_font_selection_config) const;
 
     wil::com_ptr<IDWriteTypography> get_default_typography();
 

--- a/direct_write_emoji.cpp
+++ b/direct_write_emoji.cpp
@@ -3,7 +3,7 @@
 #include "direct_write.h"
 #include "emoji.h"
 
-namespace uih::direct_write {
+namespace uih::direct_write::emoji_font_fallback {
 
 namespace {
 
@@ -311,4 +311,4 @@ wil::com_ptr<IDWriteFontFallback> create_emoji_font_fallback(const wil::com_ptr<
     return new EmojiFontFallback(font_collection, std::move(base_fallback), emoji_family_name, monochrome_family_name);
 }
 
-} // namespace uih::direct_write
+} // namespace uih::direct_write::emoji_font_fallback

--- a/direct_write_emoji.h
+++ b/direct_write_emoji.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace uih::direct_write {
+namespace uih::direct_write::emoji_font_fallback {
 
 wil::com_ptr<IDWriteFontFallback> create_emoji_font_fallback(const wil::com_ptr<IDWriteFontCollection>& font_collection,
     wil::com_ptr<IDWriteFontFallback> base_fallback, const wchar_t* emoji_family_name,


### PR DESCRIPTION
This reworks how emoji font fallback is configured, adding a new `uih::direct_write::Context::create_emoji_font_fallback()` method to create an emoji IDWriteFontFallback object, and removing `uih::direct_write::TextFormat::set_emoji_font_selection_config()`.

This is part of work to better integrate this functionality into the Columns UI fonts API.