### PR TITLE
Optimise list view navigation using arrow keys

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -478,6 +478,12 @@ public:
     bool disable_redrawing();
     void enable_redrawing();
 
+    auto suspend_ensure_visible()
+    {
+        m_ensure_visible_suspended = true;
+        return gsl::finally([this]() { m_ensure_visible_suspended = false; });
+    }
+
     const char* get_item_text(size_t index, size_t column);
 
     size_t get_item_count() { return m_items.size(); }
@@ -888,6 +894,7 @@ private:
     int m_scroll_position{0};
     int m_horizontal_scroll_position{0};
     bool m_scroll_bar_update_in_progress{};
+    bool m_ensure_visible_suspended{};
     size_t m_group_count{0};
     int m_item_height{1};
     int m_group_height{1};

--- a/list_view/list_view_keyboard.cpp
+++ b/list_view/list_view_keyboard.cpp
@@ -24,15 +24,9 @@ bool ListView::on_wm_keydown(WPARAM wp, LPARAM lp)
     case VK_END:
     case VK_PRIOR:
     case VK_NEXT:
-    case VK_UP: {
-        const bool b_redraw = disable_redrawing();
-
+    case VK_UP:
         process_navigation_keydown(wp, ((HIWORD(lp) & KF_ALTDOWN) != 0), (HIWORD(lp) & KF_REPEAT) != 0);
-
-        if (b_redraw)
-            enable_redrawing();
         return true;
-    }
     case VK_SPACE: {
         if (is_ctrl_down) {
             const size_t focus = get_focus_item();

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -244,29 +244,32 @@ void ListView::process_navigation_keydown(WPARAM wp, bool alt_down, bool repeat)
         break;
     }
 
-    ensure_visible(target_item, EnsureVisibleMode::PreferMinimalScrolling);
+    {
+        auto _ = suspend_ensure_visible();
+        bool is_focus_selected = get_item_selected(focus);
 
-    bool focus_sel = get_item_selected(focus);
-
-    if ((GetKeyState(VK_SHIFT) & KF_UP) && (GetKeyState(VK_CONTROL) & KF_UP)) {
-        // if (!repeat) playlist_api->activeplaylist_undo_backup();
-        move_selection(target_item - focus);
-    } else if ((GetKeyState(VK_CONTROL) & KF_UP)) {
-        set_focus_item(target_item);
-    } else if (m_selection_mode == SelectionMode::Multiple && (GetKeyState(VK_SHIFT) & KF_UP)) {
-        const size_t start = m_alternate_selection ? focus : m_shift_start;
-        const pfc::bit_array_range array_select(
-            std::min(start, size_t(target_item)), abs(int(start - (target_item))) + 1);
-        if (m_alternate_selection && !focus_sel)
-            set_selection_state(array_select, pfc::bit_array_not(array_select), true);
-        else if (m_alternate_selection)
-            set_selection_state(array_select, array_select, true);
-        else
-            set_selection_state(pfc::bit_array_true(), array_select, true);
-        set_focus_item(target_item, true);
-    } else {
-        set_item_selected_single(target_item);
+        if ((GetKeyState(VK_SHIFT) & KF_UP) && (GetKeyState(VK_CONTROL) & KF_UP)) {
+            // if (!repeat) playlist_api->activeplaylist_undo_backup();
+            move_selection(target_item - focus);
+        } else if ((GetKeyState(VK_CONTROL) & KF_UP)) {
+            set_focus_item(target_item);
+        } else if (m_selection_mode == SelectionMode::Multiple && (GetKeyState(VK_SHIFT) & KF_UP)) {
+            const size_t start = m_alternate_selection ? focus : m_shift_start;
+            const pfc::bit_array_range array_select(
+                std::min(start, size_t(target_item)), abs(int(start - (target_item))) + 1);
+            if (m_alternate_selection && !is_focus_selected)
+                set_selection_state(array_select, pfc::bit_array_not(array_select), true);
+            else if (m_alternate_selection)
+                set_selection_state(array_select, array_select, true);
+            else
+                set_selection_state(pfc::bit_array_true(), array_select, true);
+            set_focus_item(target_item, true);
+        } else {
+            set_item_selected_single(target_item);
+        }
     }
+
+    ensure_visible(target_item, EnsureVisibleMode::PreferMinimalScrolling);
 }
 
 int ListView::get_default_item_height()

--- a/list_view/list_view_scroll.cpp
+++ b/list_view/list_view_scroll.cpp
@@ -38,7 +38,7 @@ void ListView::restore_scroll_position(const lv::SavedScrollPosition& position)
 
 void ListView::ensure_visible(size_t index, EnsureVisibleMode mode)
 {
-    if (index > m_items.size())
+    if (m_ensure_visible_suspended || index > m_items.size())
         return;
 
     const auto item_visibility = get_item_visibility(index);


### PR DESCRIPTION
This reduces CPU usage when navigating in the list view using the Up and Down keys.

(Previously, it suspended redrawing while handling the key press, to avoid visual artefacts. However, that meant the entire client area needed redrawing afterwards, which was unnecessary work. This removes the drawing suspension and tweaks the logic to avoid any visual artefacts.)