### PR TITLE
Avoid logging error when attempting to render text in 1px width area

### DIFF
--- a/direct_write.cpp
+++ b/direct_write.cpp
@@ -528,6 +528,9 @@ void TextLayout::render_with_transparent_background(
     const auto bitmap_width = std::min(rect_width, draw_right_px - draw_left_px);
     const auto bitmap_height = std::min(rect_height, draw_bottom_px - draw_top_px);
 
+    if (bitmap_width <= 0 || bitmap_height <= 0)
+        return;
+
     const auto is_shrunk_width = bitmap_width < rect_width;
     const auto is_shrunk_height = bitmap_height < rect_height;
 


### PR DESCRIPTION
If text was attempted to be rendered in, for example, a 1px-wide rectangle, an error would be logged if the first character was offset past that the first pixel on the x-axis.

This adds an extra check to skip rendering in that scenario and avoid the error.