### PR TITLE
Use DirectWrite to calculate list view maximum item width

### DIFF
--- a/uniscribe.h
+++ b/uniscribe.h
@@ -35,22 +35,6 @@ public:
             &m_sc, &m_ss, nullptr, enable_tabs ? &tab_def : nullptr, nullptr, &m_ssa);
     }
 
-    void text_out(int x, int y, UINT flags, const RECT* p_rc)
-    {
-        if (m_ssa)
-            ScriptStringOut(m_ssa, x, y, flags, p_rc, 0, 0, FALSE);
-    }
-
-    int get_output_character_count()
-    {
-        const int* len = m_ssa ? ScriptString_pcOutChars(m_ssa) : nullptr; // b_clip = true only
-
-        if (len && (*len < 0 || gsl::narrow_cast<size_t>(*len) > m_string_length))
-            throw std::length_error("Character count out of range.");
-
-        return len ? *len : gsl::narrow<int>(m_string_length);
-    }
-
     void get_output_size(SIZE& p_sz)
     {
         const SIZE* sz = m_ssa ? ScriptString_pSize(m_ssa) : nullptr;
@@ -66,32 +50,6 @@ public:
         SIZE sz;
         get_output_size(sz);
         return sz.cx;
-    }
-
-    long get_font_height(HDC dc)
-    {
-        long height = 0;
-        ScriptCacheGetHeight(dc, &m_scache, &height);
-        return height;
-    }
-
-    void get_character_logical_widths(int* p_array_out)
-    {
-        if (m_ssa)
-            ScriptStringGetLogicalWidths(m_ssa, p_array_out);
-    }
-
-    void get_character_logical_extents(int* p_array_out, int offset = 0) // NB RTL !
-    {
-        get_character_logical_widths(p_array_out);
-        int i;
-        int count = get_output_character_count();
-        for (i = 1; i < count; i++) {
-            p_array_out[i] += p_array_out[i - 1];
-        }
-        if (offset)
-            for (i = 0; i < count; i++)
-                p_array_out[i] += offset;
     }
 
 private:

--- a/uniscribe_text_out.cpp
+++ b/uniscribe_text_out.cpp
@@ -46,32 +46,4 @@ int get_text_width(HDC dc, const char* src, int len)
     return sz.cx;
 }
 
-int get_text_width_colour(HDC dc, const char* src, int len, bool b_ignore_tabs)
-{
-    if (!dc)
-        return 0;
-    int ptr = 0;
-    int start = 0;
-    int rv = 0;
-
-    while (ptr < len) {
-        if (src[ptr] == 3) {
-            rv += get_text_width(dc, src + start, ptr - start);
-            ptr++;
-            while (ptr < len && src[ptr] != 3)
-                ptr++;
-            if (ptr < len)
-                ptr++;
-            start = ptr;
-        } else if (b_ignore_tabs && src[ptr] == '\t') {
-            rv += get_text_width(dc, src + start, ptr - start);
-            while (ptr < len && src[ptr] == '\t')
-                ptr++;
-        } else
-            ptr++;
-    }
-    rv += get_text_width(dc, src + start, ptr - start);
-    return rv;
-}
-
 } // namespace uih

--- a/uniscribe_text_out.h
+++ b/uniscribe_text_out.h
@@ -9,9 +9,7 @@ enum alignment {
 };
 
 bool is_rect_null_or_reversed(const RECT* r);
-void get_text_size(HDC dc, const char* src, int len, SIZE& sz);
 int get_text_width(HDC dc, const char* src, int len);
-int get_text_width_colour(HDC dc, const char* src, int len, bool b_ignore_tabs = false);
 void remove_color_marks(const char* src, pfc::string_base& out, size_t len = pfc_infinite);
 
 } // namespace uih


### PR DESCRIPTION
When double-clicking on a column header divider in the list view (with auto-sizing columns off), Uniscribe was still being used to work out the maximum item width.

This switches it over to use DirectWrite (which is a bit slower).

Some more dead Uniscribe code has also been removed.