### PR TITLE
Optimise list view item replacement

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -293,7 +293,7 @@ public:
     [[nodiscard]] int get_search_box_height() const;
 
     void invalidate_all(bool b_children = false, bool non_client = false);
-    void invalidate_items(size_t index, size_t count);
+    void invalidate_items(size_t index, size_t count) const;
 
     void invalidate_items(const pfc::bit_array& mask);
     void invalidate_item_group_info_area(size_t index);

--- a/list_view/list_view_items.cpp
+++ b/list_view/list_view_items.cpp
@@ -60,10 +60,20 @@ void ListView::insert_items(size_t index_start, size_t count, const InsertItem* 
 
 void ListView::replace_items(size_t index_start, size_t count, const InsertItem* items)
 {
+    assert(count > 0);
+
+    if (count == 0)
+        return;
+
     replace_items_in_internal_state(index_start, count, items);
     calculate_item_positions(index_start);
-    update_scroll_info();
-    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
+
+    if (m_group_count > 0 || m_variable_height_items) {
+        update_scroll_info();
+        invalidate_all();
+    } else {
+        invalidate_items(index_start, count);
+    }
 }
 
 void ListView::remove_items(const pfc::bit_array& mask)

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -334,24 +334,20 @@ void ListView::update_all_items()
     update_items(0, m_items.size());
 }
 
-void ListView::invalidate_items(size_t index, size_t count)
+void ListView::invalidate_items(size_t index, size_t count) const
 {
-#if 0
-        RedrawWindow(get_wnd(), NULL, NULL, RDW_INVALIDATE | (b_update_display ? RDW_UPDATENOW : 0));
-#else
-    if (count) {
-        // size_t header_height = get_header_height();
-        const auto rc_client = get_items_rect();
-        const auto groups = gsl::narrow<int>(get_item_display_group_count(index));
-        RECT rc_invalidate = {0, get_item_position(index) - m_scroll_position + rc_client.top - groups * m_group_height,
-            RECT_CX(rc_client),
-            get_item_position(index + count - 1) - m_scroll_position + get_item_height(index + count - 1)
-                + rc_client.top};
-        if (IntersectRect(&rc_invalidate, &rc_client, &rc_invalidate)) {
-            RedrawWindow(get_wnd(), &rc_invalidate, nullptr, RDW_INVALIDATE);
-        }
-    }
-#endif
+    if (count == 0)
+        return;
+
+    const auto items_rect = get_items_rect();
+    const auto groups = gsl::narrow<int>(get_item_display_group_count(index));
+    RECT invalidate_rect
+        = {items_rect.left, get_item_position(index) - m_scroll_position + items_rect.top - groups * m_group_height,
+            items_rect.right, get_item_position_bottom(index + count - 1) - m_scroll_position + items_rect.top};
+
+    RECT visible_invalidate_rect{};
+    if (IntersectRect(&visible_invalidate_rect, &items_rect, &invalidate_rect))
+        RedrawWindow(get_wnd(), &visible_invalidate_rect, nullptr, RDW_INVALIDATE);
 }
 
 void ListView::invalidate_items(const pfc::bit_array& mask)


### PR DESCRIPTION
This optimises handling of list view item replacements when grouping is turned off by making it only invalidate the affected items.