### PR TITLE
Add render_begin() callback to list view renderers

### DIFF
--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -61,6 +61,7 @@ void ListView::render_items(HDC dc, const RECT& rc_update, int cx)
         = (SendMessage(get_wnd(), WM_QUERYUISTATE, NULL, NULL) & UISF_HIDEFOCUS) != 0 && !m_always_show_focus;
     bool b_window_focused = (wnd_focus == get_wnd()) || IsChild(get_wnd(), wnd_focus);
 
+    m_renderer->render_begin(context);
     m_renderer->render_background(context, &rc_update);
     const auto rc_items = get_items_rect();
 

--- a/list_view/list_view_renderer.h
+++ b/list_view/list_view_renderer.h
@@ -38,6 +38,8 @@ struct RendererContext {
 
 class RendererBase {
 public:
+    virtual void render_begin(RendererContext context) {}
+
     virtual void render_background(RendererContext context, const RECT* rc) = 0;
 
     virtual void render_group_info(RendererContext context, size_t index, RECT rc) {}


### PR DESCRIPTION
This adds a `render_begin()` method to `uih::lv::RendererBase` to assist with the management of cached resources.