### PR TITLE
Update emoji table to final version of Unicode 17.0.0

### DIFF
--- a/emoji.cpp
+++ b/emoji.cpp
@@ -1421,7 +1421,6 @@ const std::unordered_map<char32_t, EmojiProperties> emojis = {
     {U'\U0001FADA' /* 🫚 */, EmojiProperties{.emoji_presentation = true}},
     {U'\U0001FADB' /* 🫛 */, EmojiProperties{.emoji_presentation = true}},
     {U'\U0001FADC' /* 🫜 */, EmojiProperties{.emoji_presentation = true}},
-    {U'\U0001FADD' /* 🫝 */, EmojiProperties{.emoji_presentation = true}},
     {U'\U0001FADF' /* 🫟 */, EmojiProperties{.emoji_presentation = true}},
     {U'\U0001FAE0' /* 🫠 */, EmojiProperties{.emoji_presentation = true}},
     {U'\U0001FAE1' /* 🫡 */, EmojiProperties{.emoji_presentation = true}},


### PR DESCRIPTION
This updates the emoji list used by the alternative DirectWrite emoji font selection logic from the Unicode 17 draft to the final version of Unicode 17.0.0.

(Between the two, a single emoji of an apple core was removed.)