### PR TITLE
Fix list view PgUp and PgDn handling for very small heights

### DIFF
--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -224,16 +224,24 @@ void ListView::process_navigation_keydown(WPARAM wp, bool alt_down, bool repeat)
         target_item = total - 1;
         break;
     case VK_PRIOR:
-        if (focused_item_is_visible && focus > first_visible_item)
+        if (focused_item_is_visible && focus > first_visible_item) {
             target_item = first_visible_item;
-        else
+        } else {
             target_item = get_item_at_or_after(focus_top - gsl::narrow<int>(si.nPage));
+
+            if (target_item == focus && target_item > 0)
+                --target_item;
+        }
         break;
     case VK_NEXT:
-        if (focused_item_is_visible && focus < last_visible_item)
+        if (focused_item_is_visible && focus < last_visible_item) {
             target_item = last_visible_item;
-        else
+        } else {
             target_item = get_item_at_or_before(focus_top + gsl::narrow<int>(si.nPage));
+
+            if (target_item == focus && target_item + 1 < total)
+                ++target_item;
+        }
         break;
     case VK_UP:
         target_item = (std::max)(0, focus - 1);


### PR DESCRIPTION
This fixes a minor bug where the PgUp and PgDn keys did not do anything in the list view for very small window heights (particularly if grouping was enabled).