### PR TITLE
Allow subclassing a window multiple times

### DIFF
--- a/window_subclasser.h
+++ b/window_subclasser.h
@@ -2,7 +2,9 @@
 
 namespace uih {
 
-void subclass_window(HWND wnd,
-    std::function<std::optional<LRESULT>(WNDPROC wnd_proc, HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> message_handler);
+using SubclassedWindowHandler
+    = std::function<std::optional<LRESULT>(WNDPROC window_proc, HWND wnd, UINT msg, WPARAM wp, LPARAM lp)>;
+
+void subclass_window(HWND wnd, SubclassedWindowHandler message_handler);
 
 } // namespace uih


### PR DESCRIPTION
This updates `uih::subclass_window()` to handle the same window being subclassed multiple times.