### PR TITLE
Revamp list view search bar

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "list_view_search.h"
 #include "list_view_renderer.h"
 #include "../scroll.h"
 #include "../drag_image_d2d.h"
@@ -21,7 +22,6 @@ public:
     static constexpr short IDC_HEADER = 1001;
     static constexpr short IDC_TOOLTIP = 1002;
     static constexpr short IDC_INLINEEDIT = 667;
-    static constexpr short IDC_SEARCHBOX = 668;
 
     static constexpr unsigned MSG_KILL_INLINE_EDIT = WM_USER + 3;
     static constexpr unsigned MSG_SMOOTH_SCROLL = WM_USER + 4;
@@ -363,9 +363,6 @@ public:
     [[nodiscard]] int get_item_area_height() const;
 
     [[nodiscard]] int get_items_top() const { return get_items_rect().top; }
-
-    void get_search_box_rect(LPRECT rc) const;
-    [[nodiscard]] int get_search_box_height() const;
 
     void invalidate_all(bool b_children = false, bool non_client = false);
     void invalidate_items(size_t index, size_t count) const;
@@ -822,10 +819,16 @@ protected:
 
     void clear_sort_column() { set_sort_column({}, false); }
 
-    void show_search_box(const char* label, bool b_focus = true);
-    void close_search_box(bool b_notify = true);
-    bool is_search_box_open();
-    void focus_search_box();
+    void show_search_box(const char* label);
+
+    void close_search_box() { m_search_bar.destroy(); }
+
+    void set_search_bar_host(lv::SearchBarHost::Ptr search_bar_host)
+    {
+        m_search_bar.set_host(std::move(search_bar_host));
+    }
+
+    void set_search_bar_results_text(std::wstring_view results_text) { m_search_bar.set_results_text(results_text); }
 
 private:
     struct ItemsFontConfig {
@@ -900,9 +903,6 @@ private:
     [[nodiscard]] virtual const char* get_drag_unit_singular() const { return "item"; }
     [[nodiscard]] virtual const char* get_drag_unit_plural() const { return "items"; }
 
-    virtual void notify_on_search_box_contents_change(const char* p_str) {}
-    virtual void notify_on_search_box_close() {}
-
     virtual bool notify_before_create_inline_edit(
         const pfc::list_base_const_t<size_t>& indices, size_t column, bool b_source_mouse)
     {
@@ -931,6 +931,8 @@ private:
     void process_navigation_keydown(WPARAM wp, bool alt_down, bool repeat);
     std::optional<LRESULT> on_wm_notify_header(LPNMHDR lpnm);
     bool on_wm_keydown(WPARAM wp, LPARAM lp);
+    void on_kill_focus(HWND new_focus_wnd);
+    void on_set_focus(HWND old_focus_wnd);
 
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
@@ -951,10 +953,6 @@ private:
     void set_inline_edit_rect() const;
 
     void on_search_string_change(WCHAR c);
-
-    static LRESULT WINAPI s_on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
-    LRESULT on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
-    void update_search_box_hot_status(const POINT& pt);
 
     void reset_columns();
 
@@ -1100,12 +1098,8 @@ private:
     bool m_have_indent_column{};
     int m_root_group_indentation_amount{};
 
-    HWND m_search_editbox{nullptr};
-    WNDPROC m_proc_search_edit{nullptr};
-    pfc::string8 m_search_label;
-    bool m_search_box_hot{false};
-    // HTHEME m_search_box_theme;
-    // gdi_object_t<HBRUSH>::ptr_t m_search_box_hot_brush, m_search_box_nofocus_brush;
+    lv::SearchBar m_search_bar;
+
     bool m_is_high_contrast_active{};
 
     bool m_group_level_indentation_enabled{true};

--- a/list_view/list_view_inline_edit.cpp
+++ b/list_view/list_view_inline_edit.cpp
@@ -111,8 +111,10 @@ LRESULT ListView::on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM l
             PostMessage(get_wnd(), MSG_KILL_INLINE_EDIT, 0, 0);
         }
         invalidate_all();
+        on_kill_focus(reinterpret_cast<HWND>(wp));
         break;
     case WM_SETFOCUS:
+        on_set_focus(reinterpret_cast<HWND>(wp));
         break;
     case WM_GETDLGCODE:
         return CallWindowProc(m_proc_inline_edit, wnd, msg, wp, lp) | DLGC_WANTALLKEYS;
@@ -267,8 +269,6 @@ void ListView::create_inline_edit(const pfc::list_base_const_t<size_t>& indices,
         }
     }
 
-    RECT rc_playlist;
-    GetClientRect(get_wnd(), &rc_playlist);
     const auto rc_items = get_items_rect();
 
     int font_height = uih::get_font_height(m_items_font.get());

--- a/list_view/list_view_keyboard.cpp
+++ b/list_view/list_view_keyboard.cpp
@@ -55,6 +55,14 @@ bool ListView::on_wm_keydown(WPARAM wp, LPARAM lp)
     case VK_DELETE:
         return notify_on_keyboard_keydown_remove();
     case VK_F3:
+        if (m_search_bar) {
+            if (GetKeyState(VK_SHIFT) & 0x8000)
+                m_search_bar.previous();
+            else
+                m_search_bar.next();
+
+            return true;
+        }
         return notify_on_keyboard_keydown_search();
     case 'A':
         if (process_ctrl_char_shortcuts && m_selection_mode == SelectionMode::Multiple) {

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -220,6 +220,18 @@ void ListView::set_sort_column(std::optional<size_t> index, bool b_direction)
     }
 }
 
+void ListView::show_search_box(const char* label)
+{
+    if (m_search_bar) {
+        m_search_bar.select_all();
+        m_search_bar.focus();
+        return;
+    }
+
+    m_search_bar.create(get_wnd(), label, m_items_font.get(), m_item_height, m_use_dark_mode);
+    on_size();
+}
+
 void ListView::set_autosize(bool b_val)
 {
     m_autosize = b_val;
@@ -262,44 +274,39 @@ void ListView::on_size(int cxd, int cyd, bool b_update_scroll)
 
     RECT rc{};
     GetClientRect(get_wnd(), &rc);
-    int cx = RECT_CX(rc);
+    int cx = wil::rect_width(rc);
 
-    auto old_search_height = get_search_box_height();
-    auto new_search_height = m_search_editbox ? m_item_height + scale_dpi_value(4) : 0;
+    m_search_bar.reposition(wil::rect_width(rc), wil::rect_height(rc));
 
-    if (m_search_editbox) {
-        SetWindowPos(m_search_editbox, nullptr, 0, 0, cx, new_search_height, SWP_NOZORDER);
-    }
+    const auto new_header_height = calculate_header_height();
 
-    auto new_header_height = calculate_header_height();
-    if (new_header_height != RECT_CY(rc_header) && m_wnd_header)
+    if (new_header_height != wil::rect_height(rc_header) && m_wnd_header)
         // Update height because affects scroll info
-        SetWindowPos(m_wnd_header, nullptr, -m_horizontal_scroll_position, new_search_height,
-            cx + m_horizontal_scroll_position, new_header_height, SWP_NOZORDER);
+        SetWindowPos(m_wnd_header, nullptr, -m_horizontal_scroll_position, 0, cx + m_horizontal_scroll_position,
+            new_header_height, SWP_NOZORDER);
 
     if (b_update_scroll)
         update_scroll_info();
 
-    if (m_autosize)
+    if (m_autosize) {
         update_column_sizes();
-    if (m_autosize)
         update_header();
+    }
 
     GetClientRect(get_wnd(), &rc);
     cx = RECT_CX(rc);
 
     // Reposition again due to potential vertical scrollbar changes
     if (m_wnd_header)
-        SetWindowPos(m_wnd_header, nullptr, -m_horizontal_scroll_position, new_search_height,
-            cx + m_horizontal_scroll_position, new_header_height, SWP_NOZORDER);
+        SetWindowPos(m_wnd_header, nullptr, -m_horizontal_scroll_position, 0, cx + m_horizontal_scroll_position,
+            new_header_height, SWP_NOZORDER);
 
-    if (m_search_editbox) {
-        SetWindowPos(m_search_editbox, nullptr, 0, 0, cx, new_search_height, SWP_NOZORDER);
-    }
+    m_search_bar.reposition(wil::rect_width(rc), wil::rect_height(rc));
 
-    if (new_header_height != RECT_CY(rc_header))
+    if (new_header_height != wil::rect_height(rc_header))
         RedrawWindow(m_wnd_header, nullptr, nullptr, RDW_INVALIDATE);
-    if (m_autosize || new_header_height != RECT_CY(rc_header) || get_search_box_height() != old_search_height)
+
+    if (m_autosize || new_header_height != wil::rect_height(rc_header))
         invalidate_all();
 }
 
@@ -309,7 +316,7 @@ RECT ListView::get_items_rect() const
 
     GetClientRect(get_wnd(), &rc);
     rc.top += get_header_height();
-    rc.top += get_search_box_height();
+    rc.bottom -= m_search_bar.get_total_height();
 
     if (rc.bottom < rc.top)
         rc.bottom = rc.top;
@@ -463,8 +470,15 @@ void ListView::on_focus_change(size_t index_prev, size_t index_new)
 
 void ListView::invalidate_all(bool b_children, bool non_client)
 {
+    std::optional<RECT> invalidate_rect;
+
+    if (m_search_bar && !b_children) {
+        invalidate_rect.emplace();
+        invalidate_rect = get_items_rect();
+    }
+
     auto flags = RDW_INVALIDATE | (b_children ? RDW_ALLCHILDREN : 0) | (non_client ? RDW_FRAME : 0);
-    RedrawWindow(get_wnd(), nullptr, nullptr, flags);
+    RedrawWindow(get_wnd(), invalidate_rect ? &*invalidate_rect : nullptr, nullptr, flags);
 }
 
 void ListView::update_items(size_t index, size_t count)
@@ -835,6 +849,8 @@ void ListView::set_use_dark_mode(bool use_dark_mode)
     set_inline_edit_window_theme();
     set_inline_edit_rect();
     set_tooltip_window_theme();
+
+    m_search_bar.set_use_dark_mode(use_dark_mode);
 }
 
 void ListView::set_vertical_item_padding(int val)
@@ -966,4 +982,19 @@ void ListView::set_edge_style(uint32_t b_val)
         SetWindowPos(get_wnd(), nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_FRAMECHANGED);
     }
 }
+
+void ListView::on_kill_focus(HWND new_focus_wnd)
+{
+    invalidate_all();
+    if (!new_focus_wnd || (new_focus_wnd != get_wnd() && !IsChild(get_wnd(), new_focus_wnd)))
+        notify_on_kill_focus(new_focus_wnd);
+}
+
+void ListView::on_set_focus(HWND old_focus_wnd)
+{
+    invalidate_all();
+    if (!old_focus_wnd || (old_focus_wnd != get_wnd() && !IsChild(get_wnd(), old_focus_wnd)))
+        notify_on_set_focus(old_focus_wnd);
+}
+
 } // namespace uih

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -30,6 +30,11 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             [this](ScrollAxis axis, int position) { return clamp_scroll_position(get_wnd(), axis, position); },
             [this](ScrollAxis axis, int new_position) { internal_scroll(new_position, axis); });
 
+        m_search_bar.on_kill_focus([&](HWND new_focus_wnd) { on_kill_focus(new_focus_wnd); });
+        m_search_bar.on_set_focus([&](HWND old_focus_wnd) { on_set_focus(old_focus_wnd); });
+
+        m_search_bar.on_destroy([&] { on_size(); });
+
         // For dark mode, the window needs to have the DarkMode_Explorer theme to get dark scroll bars,
         // but we also need access to DarkMode_ItemsView themes. To do this, a dummy window with a
         // different window theme is created.
@@ -101,6 +106,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         m_direct_write_context.reset();
         m_drag_image_creator.reset();
         m_smooth_scroll_helper->shut_down();
+        m_search_bar.shut_down();
         notify_on_destroy();
         return 0;
     case WM_NCDESTROY:
@@ -120,6 +126,27 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_MENUSELECT:
         notify_on_menu_select(wp, lp);
         break;
+    case WM_ERASEBKGND: {
+        const auto dc = reinterpret_cast<HDC>(wp);
+        const auto dc_wnd = WindowFromDC(dc);
+
+        if (dc_wnd == wnd)
+            return FALSE;
+
+        auto _ = wil::SelectObject(dc, GetStockObject(DC_BRUSH));
+
+        if (m_use_dark_mode) {
+            const auto colours = render_get_colour_data();
+            SetDCBrushColor(dc, colours.m_background);
+        } else {
+            SetDCBrushColor(dc, GetSysColor(COLOR_BTNFACE));
+        }
+
+        RECT client_rect{};
+        GetClientRect(wnd, &client_rect);
+        PatBlt(dc, 0, 0, client_rect.right, client_rect.bottom, PATCOPY);
+        return TRUE;
+    }
     case WM_PAINT: {
         PAINTSTRUCT ps{};
         const auto dc = wil::BeginPaint(wnd, &ps);
@@ -142,14 +169,10 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         return TRUE;
     }
     case WM_SETFOCUS:
-        invalidate_all();
-        if (!HWND(wp) || (HWND(wp) != wnd && !IsChild(wnd, HWND(wp))))
-            notify_on_set_focus(HWND(wp));
+        on_set_focus(reinterpret_cast<HWND>(wp));
         break;
     case WM_KILLFOCUS:
-        invalidate_all();
-        if (!HWND(wp) || (HWND(wp) != wnd && !IsChild(wnd, HWND(wp))))
-            notify_on_kill_focus(HWND(wp));
+        on_kill_focus(reinterpret_cast<HWND>(wp));
         break;
     case WM_MOUSEACTIVATE:
         if (GetFocus() != wnd)
@@ -228,12 +251,10 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     }
                 }
             }
-        } else // if (hit_result.result != hit_test_)
-        {
+        } else if (hit_result.category != HitTestCategory::BelowViewport) {
             if (m_selection_mode != SelectionMode::SingleStrict)
                 set_selection_state(pfc::bit_array_true(), pfc::bit_array_false());
         }
-        // console::formatter() << hit_result.result ;
     }
         return 0;
     case WM_LBUTTONUP: {
@@ -333,7 +354,8 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 set_selection_state(pfc::bit_array_true(), pfc::bit_array_range(index, count));
 
             set_focus_item(index);
-        } else if (m_selection_mode != SelectionMode::SingleStrict) {
+        } else if (hit_result.category != HitTestCategory::BelowViewport
+            && m_selection_mode != SelectionMode::SingleStrict) {
             set_selection_state(pfc::bit_array_true(), pfc::bit_array_false());
         }
         break;
@@ -462,9 +484,12 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
         HitTestResult hit_result;
         hit_test_ex(pt, hit_result);
-        if (notify_on_middleclick(hit_result.category == HitTestCategory::OnUnobscuredItem, hit_result.index))
-            return 0;
-    } break;
+
+        if (hit_result.category != HitTestCategory::BelowViewport)
+            notify_on_middleclick(hit_result.category == HitTestCategory::OnUnobscuredItem, hit_result.index);
+
+        return 0;
+    }
     case WM_MOUSEHWHEEL:
     case WM_MOUSEWHEEL: {
         const auto style = GetWindowLongPtr(get_wnd(), GWL_STYLE);
@@ -544,35 +569,23 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         return 0;
     case WM_COMMAND:
         switch (LOWORD(wp)) {
-        case IDC_INLINEEDIT:
+        case lv::ID_SEARCH_BAR_UP:
+            m_search_bar.previous();
+            break;
+        case lv::ID_SEARCH_BAR_DOWN:
+            m_search_bar.next();
+            break;
+        case lv::ID_SEARCH_BAR_CLOSE:
+            close_search_box();
+            break;
+        case lv::IDC_SEARCH_BAR_EDIT:
             switch (HIWORD(wp)) {
-            case EN_KILLFOCUS: {
-                HWND wnd_focus = GetFocus();
-                if (!HWND(wnd_focus) || (HWND(wnd_focus) != wnd && !IsChild(wnd, wnd_focus)))
-                    notify_on_kill_focus(wnd_focus);
+            case EN_CHANGE:
+                m_search_bar.on_string_change();
                 break;
             }
-            }
             break;
-        case IDC_SEARCHBOX:
-            switch (HIWORD(wp)) {
-            case EN_CHANGE: {
-                pfc::string8 text;
-                uih::get_window_text(reinterpret_cast<HWND>(lp), text);
-                notify_on_search_box_contents_change(text);
-            } break;
-            case EN_KILLFOCUS: {
-                RedrawWindow(HWND(lp), nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE);
-                HWND wnd_focus = GetFocus();
-                if (!HWND(wnd_focus) || (HWND(wnd_focus) != wnd && !IsChild(wnd, wnd_focus)))
-                    notify_on_kill_focus(wnd_focus);
-            } break;
-            case EN_SETFOCUS:
-                RedrawWindow(HWND(lp), nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE);
-                break;
-            };
-            break;
-        };
+        }
         break;
     case WM_CTLCOLOREDIT:
     case WM_CTLCOLORSTATIC: {
@@ -582,7 +595,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (!wnd_edit)
             break;
 
-        if (wnd_edit == m_wnd_inline_edit && m_use_dark_mode) {
+        if ((wnd_edit == m_wnd_inline_edit || wnd_edit == m_search_bar.get_edit_wnd()) && m_use_dark_mode) {
             SetTextColor(dc, m_dark_edit_text_colour);
             SetBkColor(dc, m_dark_edit_background_colour);
 
@@ -591,31 +604,14 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             }
             return reinterpret_cast<LPARAM>(m_edit_background_brush.get());
         }
-
-        if (wnd_edit == m_search_editbox) {
-            /*POINT pt;
-            GetMessagePos(&pt);
-            HWND wnd_focus = GetFocus();
-
-            bool b_hot = WindowFromPoint(pt) == m_search_editbox;*/
-            bool b_focused = GetFocus() == m_search_editbox;
-
-            if (b_focused)
-                return (LRESULT)GetSysColorBrush(COLOR_WINDOW);
-
-            if (m_search_box_hot)
-                return (LRESULT)GetSysColorBrush(
-                    COLOR_WINDOW); // m_search_box_hot_brush.get();//GetSysColorBrush(COLOR_BTNFACE);
-
-            return (LRESULT)GetSysColorBrush(IsThemeActive() && IsAppThemed()
-                    ? COLOR_BTNFACE
-                    : COLOR_WINDOW); // m_search_box_nofocus_brush.get();//GetSysColorBrush(COLOR_3DLIGHT);
-        }
         break;
     }
     case WM_NOTIFY: {
         const auto lpnm = reinterpret_cast<LPNMHDR>(lp);
-        if (m_wnd_header && lpnm->hwndFrom == m_wnd_header) {
+        if (lpnm->code == NM_TOOLTIPSCREATED) {
+            const auto lpnmttc = reinterpret_cast<LPNMTOOLTIPSCREATED>(lp);
+            SetWindowTheme(lpnmttc->hwndToolTips, m_use_dark_mode ? L"DarkMode_Explorer" : nullptr, nullptr);
+        } else if (m_wnd_header && lpnm->hwndFrom == m_wnd_header) {
             if (auto result = on_wm_notify_header(lpnm))
                 return *result;
         } else if (m_wnd_tooltip && lpnm->hwndFrom == m_wnd_tooltip) {
@@ -688,10 +684,11 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 } else {
                     px = pt;
                     ScreenToClient(wnd, &px);
-                    RECT rc;
-                    GetClientRect(wnd, &rc);
-                    if (!PtInRect(&rc, px))
-                        break;
+
+                    const auto items_rect = get_items_rect();
+
+                    if (!PtInRect(&items_rect, px))
+                        return 0;
                 }
             }
             if (notify_on_contextmenu(pt, from_keyboard))

--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -51,7 +51,7 @@ int ListView::measure_text_width(size_t item_index, size_t column_index)
         initial_format ? *initial_format : text_style::FormatProperties{});
 }
 
-void ListView::render_items(HDC dc, const RECT& rc_update)
+void ListView::render_items(HDC dc, const RECT& paint_rect)
 {
     auto _ = wil::SelectObject(dc, GetStockObject(DC_BRUSH));
 
@@ -70,16 +70,29 @@ void ListView::render_items(HDC dc, const RECT& rc_update)
     size_t highlight_index = get_highlight_item();
     size_t index_focus = get_focus_item();
     HWND wnd_focus = GetFocus();
-    const bool should_hide_focus
-        = (SendMessage(get_wnd(), WM_QUERYUISTATE, NULL, NULL) & UISF_HIDEFOCUS) != 0 && !m_always_show_focus;
+    const bool should_hide_focus = (SendMessage(get_wnd(), WM_QUERYUISTATE, NULL, NULL) & UISF_HIDEFOCUS) != 0
+        && !m_always_show_focus && (!m_search_bar || wnd_focus != m_search_bar.get_edit_wnd());
     bool b_window_focused = (wnd_focus == get_wnd()) || IsChild(get_wnd(), wnd_focus);
-
-    m_renderer->render_begin(context);
-    m_renderer->render_background(context, &rc_update);
-
     const auto rc_items = get_items_rect();
 
-    if (rc_update.bottom <= rc_update.top || rc_update.bottom < rc_items.top)
+    m_renderer->render_begin(context);
+
+    RECT items_paint_rect{};
+
+    if (m_search_bar) {
+        const auto search_area_rect
+            = m_search_bar.render(dc, rc_items.right, rc_items.bottom, context.colours, m_items_text_format);
+
+        SubtractRect(&items_paint_rect, &paint_rect, &search_area_rect);
+        ExcludeClipRect(
+            dc, search_area_rect.left, search_area_rect.top, search_area_rect.right, search_area_rect.bottom);
+    } else {
+        items_paint_rect = paint_rect;
+    }
+
+    m_renderer->render_background(context, &items_paint_rect);
+
+    if (items_paint_rect.bottom <= items_paint_rect.top || items_paint_rect.bottom < rc_items.top)
         return;
 
     size_t i;
@@ -90,14 +103,15 @@ void ListView::render_items(HDC dc, const RECT& rc_update)
 
     bool b_show_group_info_area = get_show_group_info_area();
 
-    i = gsl::narrow<size_t>(
-        get_item_at_or_before((rc_update.top > rc_items.top ? rc_update.top - rc_items.top : 0) + m_scroll_position));
+    i = gsl::narrow<size_t>(get_item_at_or_before(
+        (items_paint_rect.top > rc_items.top ? items_paint_rect.top - rc_items.top : 0) + m_scroll_position));
 
     size_t i_start = i;
     size_t i_end = gsl::narrow<size_t>(get_item_at_or_after(
-        (rc_update.bottom > rc_items.top + 1 ? rc_update.bottom - rc_items.top - 1 : 0) + m_scroll_position));
+        (items_paint_rect.bottom > rc_items.top + 1 ? items_paint_rect.bottom - rc_items.top - 1 : 0)
+        + m_scroll_position));
 
-    const auto stuck_headers_height = rc_update.top > rc_items.top ? get_stuck_group_headers_height() : 0;
+    const auto stuck_headers_height = items_paint_rect.top > rc_items.top ? get_stuck_group_headers_height() : 0;
     bool has_excluded_stuck_headers{};
 
     auto exclude_sticky_headers_from_clip_region = [&](const RECT& render_area) {
@@ -140,7 +154,7 @@ void ListView::render_items(HDC dc, const RECT& rc_update)
 
             const RECT rc = {x, y, x + cx, y + m_group_height};
 
-            if (rc.top >= rc_update.bottom)
+            if (rc.top >= items_paint_rect.bottom)
                 break;
 
             const auto indentation
@@ -164,7 +178,7 @@ void ListView::render_items(HDC dc, const RECT& rc_update)
             if (is_first_item || i == item_group_start) {
                 RECT rc_group_info = get_item_group_info_area_render_rect(item_group_start, rc_items);
 
-                if (rc_group_info.top < rc_update.bottom) {
+                if (rc_group_info.top < items_paint_rect.bottom) {
                     exclude_sticky_headers_from_clip_region(rc_group_info);
 
                     if (RectVisible(dc, &rc_group_info))
@@ -177,7 +191,7 @@ void ListView::render_items(HDC dc, const RECT& rc_update)
             get_item_position(i) - m_scroll_position + rc_items.top, cx - m_horizontal_scroll_position,
             get_item_position(i) + get_item_height(i) - m_scroll_position + rc_items.top};
 
-        if (rc_item.top >= rc_update.bottom)
+        if (rc_item.top >= items_paint_rect.bottom)
             break;
 
         exclude_sticky_headers_from_clip_region(rc_item);

--- a/list_view/list_view_search.cpp
+++ b/list_view/list_view_search.cpp
@@ -2,197 +2,415 @@
 
 #include "list_view.h"
 
-namespace uih {
+using namespace wil::literals;
+using namespace uih::literals::spx;
 
-bool ListView::is_search_box_open()
+namespace uih::lv {
+
+namespace {
+
+struct ToolbarButtonConfig {
+    SearchBarIconId icon_id{};
+    int command_id{};
+    wil::zwstring_view label;
+};
+
+struct CreateToolbarResult {
+    wil::unique_hwnd wnd;
+    int width{};
+    int height{};
+};
+
+constexpr std::array left_commands{
+    ToolbarButtonConfig{SearchBarIconId::Up, ID_SEARCH_BAR_UP, L"Previous result"_zv},
+    ToolbarButtonConfig{SearchBarIconId::Down, ID_SEARCH_BAR_DOWN, L"Next result"_zv},
+};
+
+constexpr std::array right_commands{
+    ToolbarButtonConfig{SearchBarIconId::Close, ID_SEARCH_BAR_CLOSE, L"Close search bar"_zv},
+};
+
+template <size_t button_count>
+wil::unique_himagelist create_toolbar_imagelist(const SearchBarHost::Ptr& host,
+    const std::array<ToolbarButtonConfig, button_count>& buttons, int width, int height, bool is_dark)
 {
-    return m_search_editbox != nullptr;
+    wil::unique_himagelist imagelist(ImageList_Create(width, height, ILC_COLOR32, 0, 0));
+    ImageList_SetImageCount(imagelist.get(), gsl::narrow<int>(buttons.size()));
+
+    for (auto&& [index, button] : ranges::views::enumerate(buttons)) {
+        const auto icon = host->create_icon(button.icon_id, width, height, is_dark);
+
+        if (std::holds_alternative<wil::unique_hbitmap>(icon))
+            ImageList_Replace(
+                imagelist.get(), gsl::narrow<int>(index), std::get<wil::unique_hbitmap>(icon).get(), nullptr);
+        else
+            ImageList_ReplaceIcon(imagelist.get(), gsl::narrow<int>(index), std::get<wil::unique_hicon>(icon).get());
+    }
+
+    return imagelist;
 }
-void ListView::focus_search_box()
+
+bool is_imagelist_same_size(HIMAGELIST imagelist, int width, int height)
 {
-    if (m_search_editbox)
-        SetFocus(m_search_editbox);
+    int current_width{};
+    int current_height{};
+    ImageList_GetIconSize(imagelist, &current_width, &current_height);
+    return current_width == width && current_height == height;
 }
 
-void ListView::show_search_box(const char* label, bool b_focus)
+template <size_t button_count>
+CreateToolbarResult create_toolbar(HWND parent_wnd, uint32_t ctrl_id, HIMAGELIST imagelist,
+    const std::array<ToolbarButtonConfig, button_count>& buttons, bool is_dark)
 {
-    if (!m_search_editbox) {
-        m_search_editbox
-            = CreateWindowEx(WS_EX_CLIENTEDGE, WC_EDIT, L"" /*pfc::stringcvt::string_os_from_utf8("").get_ptr()*/,
-                WS_CHILD | WS_CLIPSIBLINGS | ES_LEFT | WS_VISIBLE | WS_CLIPCHILDREN | ES_AUTOHSCROLL | WS_TABSTOP, 0, 0,
-                0, 0, get_wnd(), HMENU(668), wil::GetModuleInstanceHandle(), nullptr);
+    wil::unique_hwnd wnd(CreateWindowEx(WS_EX_TOOLWINDOW, TOOLBARCLASSNAME, nullptr,
+        WS_CHILD | WS_CLIPSIBLINGS | WS_CLIPCHILDREN | TBSTYLE_FLAT | TBSTYLE_LIST | TBSTYLE_TRANSPARENT
+            | TBSTYLE_TOOLTIPS | CCS_NORESIZE | CCS_NOPARENTALIGN | CCS_NODIVIDER,
+        0, 0, 0, 0, parent_wnd, reinterpret_cast<HMENU>(static_cast<size_t>(ctrl_id)), wil::GetModuleInstanceHandle(),
+        nullptr));
 
-        m_search_label = label;
+    SetWindowTheme(wnd.get(), is_dark ? L"DarkMode" : nullptr, nullptr);
 
-        SetWindowLongPtr(m_search_editbox, GWLP_USERDATA, (LPARAM)(this));
-        m_proc_search_edit
-            = (WNDPROC)SetWindowLongPtr(m_search_editbox, GWLP_WNDPROC, (LPARAM)(s_on_search_edit_message));
-        // SetWindowPos(m_wnd_inline_edit,HWND_TOP,0,0,0,0,SWP_NOMOVE|SWP_NOSIZE);
-        SendMessage(m_search_editbox, WM_SETFONT, (WPARAM)m_items_font.get(), MAKELONG(TRUE, 0));
-        SetWindowTheme(m_search_editbox, L"SearchBoxEdit", nullptr);
+    const unsigned icon_width = GetSystemMetrics(SM_CXSMICON);
+    const unsigned icon_height = GetSystemMetrics(SM_CYSMICON);
 
-        // m_search_box_theme = OpenThemeData(m_search_editbox, L"Edit");
-        /*    COLORREF cr = NULL;
-            GetThemeColor(m_theme, NULL, NULL, TMT_EDGEHIGHLIGHTCOLOR, &cr);
-            m_search_box_hot_brush = CreateSolidBrush(cr);
-            BYTE b = LOBYTE(HIWORD(cr)), g = HIBYTE(LOWORD(cr)), r = LOBYTE(LOWORD(cr));
-            r-=r/20;
-            g-=g/20;
-            b-=b/20;
-            //r = pfc::rint32(r*0.9);
-            //g = pfc::rint32(g*0.9);
-            //b = pfc::rint32(b*0.9);
-            cr = RGB(r, g, b);
-            m_search_box_nofocus_brush = CreateSolidBrush(cr);*/
-        // SendMessage(m_search_editbox, EM_SETMARGINS, EC_LEFTMARGIN, 0);
-        Edit_SetCueBannerText(m_search_editbox, pfc::stringcvt::string_wide_from_utf8(label).get_ptr());
-        if (b_focus)
-            SetFocus(m_search_editbox);
-        on_size();
+    std::array<TBBUTTON, button_count> tbbuttons{};
 
-#if 0
-            HTHEME thm = OpenThemeData(m_search_editbox, L"Edit");
-            size_t i;
-            for (i = TMT_RESERVEDLOW; i < TMT_RESERVEDHIGH; i++)
-            {
-                COLORREF cr = 0;
-                if (SUCCEEDED(GetThemeColor(thm, EP_BACKGROUND, EBS_NORMAL, i, &cr)) && cr)
-                    console::formatter() << i << " " << (unsigned)GetRValue(cr) << " " << (unsigned)GetGValue(cr) << " " << (unsigned)GetBValue(cr);
-                cr = 0;
-                if (SUCCEEDED(GetThemeColor(thm, EP_BACKGROUND, EBS_HOT, i, &cr)) && cr)
-                    console::formatter() << i << " " << (unsigned)GetRValue(cr) << " " << (unsigned)GetGValue(cr) << " " << (unsigned)GetBValue(cr);
-                cr = 0;
-                if (SUCCEEDED(GetThemeColor(thm, EP_BACKGROUND, EBS_FOCUSED, i, &cr)) && cr)
-                    console::formatter() << i << " " << (unsigned)GetRValue(cr) << " " << (unsigned)GetGValue(cr) << " " << (unsigned)GetBValue(cr);
+    for (auto&& [index, command, tbbutton] : ranges::views::zip(ranges::views::iota(int{}), buttons, tbbuttons)) {
+        tbbutton.iBitmap = index;
+        tbbutton.idCommand = command.command_id;
+        tbbutton.fsState = TBSTATE_ENABLED;
+        tbbutton.fsStyle = BTNS_AUTOSIZE | BTNS_BUTTON;
+        tbbutton.iString = reinterpret_cast<INT_PTR>(command.label.c_str());
+    }
+
+    SendMessage(wnd.get(), TB_SETEXTENDEDSTYLE, 0, TBSTYLE_EX_DRAWDDARROWS | TBSTYLE_EX_MIXEDBUTTONS);
+    SendMessage(wnd.get(), TB_SETBITMAPSIZE, 0, MAKELONG(icon_width, icon_height));
+
+    SendMessage(wnd.get(), TB_SETIMAGELIST, 0, reinterpret_cast<LPARAM>(imagelist));
+
+    SendMessage(wnd.get(), TB_BUTTONSTRUCTSIZE, sizeof(TBBUTTON), 0);
+    SendMessage(wnd.get(), TB_ADDBUTTONS, tbbuttons.size(), reinterpret_cast<LPARAM>(tbbuttons.data()));
+
+    SendMessage(wnd.get(), TB_AUTOSIZE, 0, 0);
+
+    RECT last_button_rect{};
+    SendMessage(wnd.get(), TB_GETITEMRECT, button_count - 1, reinterpret_cast<LPARAM>(&last_button_rect));
+
+    return {std::move(wnd), last_button_rect.right, last_button_rect.bottom};
+}
+
+void create_toolbar_and_imagelist(SearchBarToolbarState& toolbar, auto&& commands, HWND parent_wnd,
+    const SearchBarHost::Ptr& host, uint32_t control_id, int icon_width, int icon_height, bool is_dark)
+{
+    if (toolbar.wnd)
+        return;
+
+    if (!toolbar.imagelist || !is_imagelist_same_size(toolbar.imagelist.get(), icon_width, icon_height))
+        toolbar.imagelist = create_toolbar_imagelist(
+            host, std::forward<decltype(commands)>(commands), icon_width, icon_height, is_dark);
+
+    auto result = create_toolbar(
+        parent_wnd, control_id, toolbar.imagelist.get(), std::forward<decltype(commands)>(commands), is_dark);
+
+    toolbar.wnd = std::move(result.wnd);
+    toolbar.width = result.width;
+    toolbar.height = result.height;
+}
+
+} // namespace
+
+void SearchBar::create(HWND parent_wnd, const char* label, HFONT font, int item_height, bool is_dark)
+{
+    if (m_edit_control)
+        return;
+
+    m_parent_wnd = parent_wnd;
+    m_item_height = item_height;
+    m_is_dark = is_dark;
+
+    m_edit_control.reset(CreateWindowEx(WS_EX_CLIENTEDGE, WC_EDIT, L"",
+        WS_CHILD | WS_CLIPSIBLINGS | ES_LEFT | WS_CLIPCHILDREN | ES_AUTOHSCROLL | WS_TABSTOP, 0, 0, 0, 0, parent_wnd,
+        reinterpret_cast<HMENU>(IDC_SEARCH_BAR_EDIT), wil::GetModuleInstanceHandle(), nullptr));
+
+    if (!m_edit_control)
+        return;
+
+    m_search_label = label;
+
+    enhance_edit_control(m_edit_control.get());
+
+    subclass_window(
+        m_edit_control.get(), [&](auto wnd_proc, auto wnd, auto msg, auto wp, auto lp) -> std::optional<LRESULT> {
+            switch (msg) {
+            case WM_KILLFOCUS:
+                m_on_kill_focus(reinterpret_cast<HWND>(wp));
+                break;
+            case WM_SETFOCUS:
+                m_on_set_focus(reinterpret_cast<HWND>(wp));
+                break;
+            case WM_KEYDOWN:
+                m_prevent_wm_char_processing = false;
+
+                switch (wp) {
+                case VK_TAB:
+                    uih::handle_tab_down(wnd);
+                    return 0;
+                case VK_ESCAPE:
+                    destroy();
+                    return 0;
+                case VK_UP:
+                    m_search_bar_host->on_previous();
+                    return 0;
+                case VK_DOWN:
+                    m_search_bar_host->on_next();
+                    return 0;
+                case VK_F3:
+                    if (GetKeyState(VK_SHIFT) & 0x8000)
+                        m_search_bar_host->on_previous();
+                    else
+                        m_search_bar_host->on_next();
+                    return 0;
+                case VK_RETURN:
+                    m_prevent_wm_char_processing = true;
+                    m_search_bar_host->on_return();
+                    return 0;
+                }
+                break;
+            case WM_SYSKEYDOWN:
+                m_prevent_wm_char_processing = false;
+                break;
+            case WM_CHAR:
+                if (m_prevent_wm_char_processing) {
+                    m_prevent_wm_char_processing = false;
+                    return 0;
+                }
+                return {};
             }
-            CloseThemeData(thm);
-#endif
+            return {};
+        });
+
+    SendMessage(m_edit_control.get(), WM_SETFONT, (WPARAM)font, MAKELONG(TRUE, 0));
+    SetWindowTheme(m_edit_control.get(), is_dark ? L"DarkMode_CFD" : nullptr, nullptr);
+
+    Edit_SetCueBannerTextFocused(m_edit_control.get(), mmh::to_utf16(label).c_str(), true);
+
+    focus();
+
+    const unsigned icon_width = GetSystemMetrics(SM_CXSMICON);
+    const unsigned icon_height = GetSystemMetrics(SM_CYSMICON);
+
+    create_toolbar_and_imagelist(m_right_toolbar, right_commands, parent_wnd, m_search_bar_host,
+        IDC_SEARCH_BAR_RIGHT_TOOLBAR, icon_width, icon_height, is_dark);
+
+    create_toolbar_and_imagelist(m_left_toolbar, left_commands, parent_wnd, m_search_bar_host,
+        IDC_SEARCH_BAR_LEFT_TOOLBAR, icon_width, icon_height, is_dark);
+
+    invalidate();
+
+    if (!m_last_string.empty()) {
+        SetWindowText(m_edit_control.get(), m_last_string.c_str());
+        select_all();
     }
+
+    ShowWindow(m_edit_control.get(), SW_SHOWNORMAL);
+
+    if (m_left_toolbar.wnd)
+        ShowWindow(m_left_toolbar.wnd.get(), SW_SHOWNORMAL);
+
+    if (m_right_toolbar.wnd)
+        ShowWindow(m_right_toolbar.wnd.get(), SW_SHOWNORMAL);
 }
-void ListView::close_search_box(bool b_notify)
+
+void SearchBar::destroy()
 {
-    if (m_search_editbox) {
-        DestroyWindow(m_search_editbox);
-        m_search_editbox = nullptr;
-    }
-    /*if (m_search_box_theme)
-    {
-        CloseThemeData(m_search_box_theme);
-        m_search_box_theme = NULL;
-    }*/
+    if (!m_edit_control)
+        return;
+
+    invalidate();
+
+    m_edit_control.reset();
     m_search_label.reset();
-    on_size();
-    if (b_notify)
-        notify_on_search_box_close();
+    m_left_toolbar.wnd.reset();
+    m_right_toolbar.wnd.reset();
+    m_search_bar_host->on_close();
+
+    m_on_destroy();
 }
 
-void ListView::get_search_box_rect(LPRECT rc) const
+void SearchBar::shut_down()
 {
-    if (m_search_editbox) {
-        *rc = uih::get_relative_rect(m_search_editbox, get_wnd());
-        // rc->top -= 2;
-        // rc->bottom += 2;
-    } else {
-        GetClientRect(get_wnd(), rc);
-        rc->top = rc->bottom;
+    m_edit_control.reset();
+    m_search_label.reset();
+    m_left_toolbar.wnd.reset();
+    m_right_toolbar.wnd.reset();
+    m_left_toolbar.imagelist.reset();
+    m_right_toolbar.imagelist.reset();
+    m_on_destroy = {};
+}
+
+SearchBar::Metrics SearchBar::get_metrics() const
+{
+    if (!m_edit_control)
+        return {};
+
+    RECT rect{};
+    GetWindowRect(m_edit_control.get(), &rect);
+
+    const auto edit_height = static_cast<int>(wil::rect_height(rect));
+    const auto edit_width = static_cast<int>(wil::rect_width(rect));
+
+    const auto total_height = std::max(edit_height, m_left_toolbar.height) + get_vertical_padding() * 2;
+
+    return {edit_width, edit_height, total_height};
+}
+
+int SearchBar::get_total_height() const
+{
+    return get_metrics().total_height;
+}
+
+void SearchBar::reposition(int client_width, int client_height) const
+{
+    const auto vertical_padding = get_vertical_padding();
+    const auto horizontal_padding = get_horizontal_padding();
+    const auto max_edit_width = 300_spx;
+    const auto edit_width = std::clamp(
+        client_width - 2 * horizontal_padding - m_left_toolbar.width - m_right_toolbar.width, 0, max_edit_width);
+    const auto edit_height = m_edit_control ? m_item_height + horizontal_padding : 0;
+    const auto total_height = std::max(edit_height, m_right_toolbar.height) + vertical_padding * 2;
+    bool should_invalidate{};
+
+    if (m_edit_control) {
+        RECT old_edit_rect{};
+        GetWindowRect(m_edit_control.get(), &old_edit_rect);
+
+        SetWindowPos(m_edit_control.get(), nullptr, 0, client_height - (total_height + edit_height) / 2, edit_width,
+            edit_height, SWP_NOZORDER);
+
+        should_invalidate = wil::rect_width(old_edit_rect) != edit_width;
     }
+
+    auto reposition_toolbar = [&](const SearchBarToolbarState& toolbar, int x) {
+        if (toolbar.wnd)
+            SetWindowPos(toolbar.wnd.get(), nullptr, x, client_height - (total_height + toolbar.height) / 2,
+                toolbar.width, toolbar.height, SWP_NOZORDER);
+    };
+
+    reposition_toolbar(m_left_toolbar, horizontal_padding + edit_width);
+    reposition_toolbar(m_right_toolbar, client_width - m_right_toolbar.width);
+
+    if (should_invalidate)
+        invalidate();
 }
-int ListView::get_search_box_height() const
+
+void SearchBar::on_string_change()
 {
-    int ret = 0;
-    if (m_search_editbox) {
-        RECT rc;
-        get_search_box_rect(&rc);
-        ret = RECT_CY(rc);
-    }
-    return ret;
+    const auto new_string = get_window_text(m_edit_control.get());
+
+    if (new_string.size() == m_last_string.size() + 1
+        && wcsncmp(m_last_string.c_str(), new_string.c_str(), m_last_string.size()) == 0)
+        m_search_bar_host->on_char(gsl::narrow<wchar_t>(new_string[new_string.size() - 1]));
+    else
+        m_search_bar_host->on_string_replaced(new_string.c_str());
+
+    m_last_string = new_string;
 }
 
-LRESULT WINAPI ListView::s_on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
+void SearchBar::set_use_dark_mode(bool is_dark)
 {
-    ListView* p_this;
-    LRESULT rv;
+    if (m_is_dark == is_dark)
+        return;
 
-    p_this = reinterpret_cast<ListView*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
+    m_is_dark = is_dark;
 
-    rv = p_this ? p_this->on_search_edit_message(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);
-    ;
+    if (m_edit_control)
+        SetWindowTheme(m_edit_control.get(), is_dark ? L"DarkMode_CFD" : nullptr, nullptr);
 
-    return rv;
+    m_left_toolbar.imagelist.reset();
+    m_right_toolbar.imagelist.reset();
+
+    const unsigned cx = GetSystemMetrics(SM_CXSMICON);
+    const unsigned cy = GetSystemMetrics(SM_CYSMICON);
+
+    auto set_toolbar_dark_mode = [&](SearchBarToolbarState& toolbar, auto&& commands) {
+        toolbar.imagelist
+            = create_toolbar_imagelist(m_search_bar_host, std::forward<decltype(commands)>(commands), cx, cy, is_dark);
+        SendMessage(toolbar.wnd.get(), TB_SETIMAGELIST, 0, reinterpret_cast<LPARAM>(toolbar.imagelist.get()));
+        SetWindowTheme(toolbar.wnd.get(), is_dark ? L"DarkMode" : nullptr, nullptr);
+
+        if (const auto tooltip_wnd = reinterpret_cast<HWND>(SendMessage(toolbar.wnd.get(), TB_GETTOOLTIPS, 0, 0)))
+            SetWindowTheme(tooltip_wnd, is_dark ? L"DarkMode_Explorer" : nullptr, nullptr);
+    };
+
+    if (m_left_toolbar.wnd)
+        set_toolbar_dark_mode(m_left_toolbar, left_commands);
+
+    if (m_right_toolbar.wnd)
+        set_toolbar_dark_mode(m_right_toolbar, right_commands);
 }
 
-LRESULT ListView::on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+void SearchBar::set_results_text(std::wstring_view new_text)
 {
-    switch (msg) {
-    case WM_KILLFOCUS:
-        break;
-    case WM_SETFOCUS:
-        break;
-    case WM_GETDLGCODE:
-        // return CallWindowProc(m_proc_search_edit,wnd,msg,wp,lp)|DLGC_WANTALLKEYS;
-        break;
-    case WM_KEYDOWN:
-        switch (wp) {
-        case VK_TAB: {
-            uih::handle_tab_down(wnd);
-        }
-        // return 0;
-        break;
-        case VK_ESCAPE:
-            close_search_box();
-            // notify_on_search_box_close();
-            return 0;
-        case VK_RETURN:
-            return 0;
-        }
-        break;
-    case WM_MOUSEMOVE: {
-        POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
-        update_search_box_hot_status(pt);
-    } break;
-#if 0
-        case WM_PAINT:
-        {
-            PAINTSTRUCT ps;
-            HDC dc = BeginPaint(wnd, &ps);
-            RECT rc;
-            GetClientRect(m_search_editbox, &rc);
-            HTHEME thm = OpenThemeData(m_search_editbox, L"SearchBox");//SearchBox
-            size_t step = rc.right / 10;
-            size_t i;
-            for (i = 0; i < 10; i++)
-            {
-                rc.left = i*step;
-                rc.right = (i + 1)*step;
-                FillRect(dc, &rc, GetSysColorBrush(COLOR_3DLIGHT));
-                DrawThemeBackground(thm, (HDC)dc, 1, i, &rc, NULL);
-            }
-            CloseThemeData(thm);
-            EndPaint(wnd, &ps);
-        }
-        return 0;
-#endif
-    }
-    return CallWindowProc(m_proc_search_edit, wnd, msg, wp, lp);
+    m_results_text = new_text;
+    invalidate();
 }
 
-void ListView::update_search_box_hot_status(const POINT& pt)
+void SearchBar::invalidate() const
 {
-    POINT pts = pt;
-    MapWindowPoints(get_wnd(), HWND_DESKTOP, &pts, 1);
+    RECT invalidate_rect{};
+    GetClientRect(m_parent_wnd, &invalidate_rect);
+    invalidate_rect.top = invalidate_rect.bottom - get_total_height();
 
-    bool b_in_wnd = WindowFromPoint(pts) == m_search_editbox;
-    bool b_focused = GetFocus() == m_search_editbox;
-    bool b_new_hot = b_in_wnd && !b_focused;
-
-    if (m_search_box_hot != b_new_hot) {
-        m_search_box_hot = b_new_hot;
-        if (m_search_box_hot)
-            SetCapture(m_search_editbox);
-        else if (GetCapture() == m_search_editbox)
-            ReleaseCapture();
-        RedrawWindow(m_search_editbox, nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE);
-    }
+    RedrawWindow(m_parent_wnd, &invalidate_rect, nullptr, RDW_INVALIDATE);
 }
 
-} // namespace uih
+RECT SearchBar::render(HDC dc, int items_width, int items_bottom, const ColourData& colours,
+    const std::optional<direct_write::TextFormat>& text_format)
+{
+    const auto metrics = get_metrics();
+
+    RECT search_area_rect = RECT{0, items_bottom, items_width, items_bottom + metrics.total_height};
+
+    if (!RectVisible(dc, &search_area_rect))
+        return search_area_rect;
+
+    SetDCBrushColor(dc, m_is_dark ? colours.m_background : GetSysColor(COLOR_BTNFACE));
+    PatBlt(dc, search_area_rect.left, search_area_rect.top, wil::rect_width(search_area_rect), metrics.total_height,
+        PATCOPY);
+
+    if (!text_format)
+        return search_area_rect;
+
+    const auto horizontal_padding = get_horizontal_padding();
+
+    const auto text_available_width
+        = items_width - metrics.edit_width - m_left_toolbar.width - m_right_toolbar.width - horizontal_padding * 3;
+
+    if (text_available_width <= 0)
+        return search_area_rect;
+
+    const auto text_layout = text_format->create_text_layout(m_results_text,
+        direct_write::px_to_dip(static_cast<float>(text_available_width)),
+        direct_write::px_to_dip(static_cast<float>(metrics.total_height)), true);
+
+    const auto text_colour = m_is_dark ? colours.m_text : GetSysColor(COLOR_BTNTEXT);
+
+    const auto left = metrics.edit_width + m_left_toolbar.width + horizontal_padding * 2;
+    RECT text_rect{left, items_bottom, left + text_available_width, items_bottom + metrics.total_height};
+
+    text_layout.render_with_transparent_background(m_parent_wnd, dc, text_rect, text_colour);
+
+    return search_area_rect;
+}
+
+int SearchBar::get_horizontal_padding()
+{
+    return 4_spx;
+}
+
+int SearchBar::get_vertical_padding()
+{
+    return 2_spx;
+}
+
+} // namespace uih::lv

--- a/list_view/list_view_search.h
+++ b/list_view/list_view_search.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "list_view_renderer.h"
+#include "../direct_write.h"
+
+namespace uih::lv {
+
+static constexpr short IDC_SEARCH_BAR_EDIT = 2000;
+static constexpr short IDC_SEARCH_BAR_LEFT_TOOLBAR = 2001;
+static constexpr short IDC_SEARCH_BAR_RIGHT_TOOLBAR = 2002;
+
+static constexpr short ID_SEARCH_BAR_UP = 2100;
+static constexpr short ID_SEARCH_BAR_DOWN = 2101;
+static constexpr short ID_SEARCH_BAR_CLOSE = 2102;
+
+enum class SearchBarIconId {
+    Up,
+    Down,
+    Close,
+};
+
+struct SearchBarHost {
+    using Ptr = std::shared_ptr<SearchBarHost>;
+
+    virtual void on_previous() = 0;
+    virtual void on_next() = 0;
+    virtual void on_return() = 0;
+    virtual void on_char(const wchar_t chr) {}
+    virtual void on_string_replaced(const wchar_t* text) {}
+    virtual void on_close() {}
+    virtual std::variant<wil::unique_hbitmap, wil::unique_hicon> create_icon(
+        SearchBarIconId icon_id, int width, int height, bool is_dark) = 0;
+
+    virtual ~SearchBarHost() {}
+};
+
+struct SearchBarToolbarState {
+    wil::unique_hwnd wnd;
+    wil::unique_himagelist imagelist;
+    int width{};
+    int height{};
+};
+
+class SearchBar {
+public:
+    using OnFocusCallback = std::function<void(HWND)>;
+    using OnDestroyCallback = std::function<void()>;
+
+    operator bool() const { return m_edit_control.is_valid(); }
+
+    void create(HWND parent_wnd, const char* label, HFONT font, int item_height, bool is_dark);
+    void destroy();
+    void shut_down();
+
+    void set_host(SearchBarHost::Ptr host) { m_search_bar_host = std::move(host); }
+    void focus() const { SetFocus(m_edit_control.get()); }
+    void select_all() const { SendMessage(m_edit_control.get(), EM_SETSEL, 0, -1); }
+
+    void on_destroy(OnDestroyCallback on_destroy) { m_on_destroy = std::move(on_destroy); }
+    void on_kill_focus(OnFocusCallback on_kill_focus) { m_on_kill_focus = std::move(on_kill_focus); }
+    void on_set_focus(OnFocusCallback on_set_focus) { m_on_set_focus = std::move(on_set_focus); }
+
+    struct Metrics {
+        int edit_width{};
+        int edit_height{};
+        int total_height{};
+    };
+
+    [[nodiscard]] Metrics get_metrics() const;
+    [[nodiscard]] int get_total_height() const;
+    [[nodiscard]] HWND get_edit_wnd() const { return m_edit_control.get(); }
+
+    void reposition(int client_width, int client_height) const;
+
+    void previous() const
+    {
+        if (m_search_bar_host)
+            m_search_bar_host->on_previous();
+    }
+
+    void next() const
+    {
+        if (m_search_bar_host)
+            m_search_bar_host->on_next();
+    }
+
+    void on_string_change();
+
+    void set_use_dark_mode(bool is_dark);
+
+    void set_results_text(std::wstring_view new_text);
+    void invalidate() const;
+    RECT render(HDC dc, int items_width, int items_bottom, const ColourData& colours,
+        const std::optional<direct_write::TextFormat>& text_format);
+
+private:
+    static int get_horizontal_padding();
+    static int get_vertical_padding();
+
+    wil::unique_hwnd m_edit_control;
+    bool m_prevent_wm_char_processing{};
+    SearchBarToolbarState m_left_toolbar;
+    SearchBarToolbarState m_right_toolbar;
+    HWND m_parent_wnd{};
+    bool m_is_dark{};
+    pfc::string8 m_search_label;
+    int m_item_height{};
+    std::wstring m_results_text;
+    SearchBarHost::Ptr m_search_bar_host;
+    std::wstring m_last_string{};
+    OnDestroyCallback m_on_destroy;
+    OnFocusCallback m_on_set_focus;
+    OnFocusCallback m_on_kill_focus;
+};
+
+} // namespace uih::lv

--- a/ui_helpers.vcxproj
+++ b/ui_helpers.vcxproj
@@ -170,6 +170,7 @@
     <ClInclude Include="emoji.h" />
     <ClInclude Include="list_view\list_view.h" />
     <ClInclude Include="list_view\list_view_renderer.h" />
+    <ClInclude Include="list_view\list_view_search.h" />
     <ClInclude Include="literals.h" />
     <ClInclude Include="ole.h" />
     <ClInclude Include="OLE\data_object.h" />

--- a/ui_helpers.vcxproj.filters
+++ b/ui_helpers.vcxproj.filters
@@ -83,6 +83,9 @@
     <ClInclude Include="scroll.h" />
     <ClInclude Include="dxgi_utils.h" />
     <ClInclude Include="dcomp_utils.h" />
+    <ClInclude Include="list_view\list_view_search.h">
+      <Filter>List View</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="message_hook.cpp" />


### PR DESCRIPTION
This ressurects the old list view search bar and makes various changes and improvements to it.

The search bar now:

- is at the bottom of the list view
- has buttons to navigate to the previous and next match
- has a close button
- has text to describe how many matches were found
- restores the previous search string when reopening the search bar
- handles F3 and Shift+F3 for navigating to the previous and next matches