### PR TITLE
Tweak list view search bar appearance

### DIFF
--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -894,6 +894,12 @@ void ListView::set_font(std::optional<direct_write::TextFormat> text_format, con
         if (m_group_count)
             update_header();
 
+        if (m_search_bar) {
+            m_search_bar.invalidate();
+            m_search_bar.set_font(m_items_font.get());
+            m_search_bar.reposition();
+        }
+
         refresh_item_positions();
     }
 }

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -30,10 +30,10 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             [this](ScrollAxis axis, int position) { return clamp_scroll_position(get_wnd(), axis, position); },
             [this](ScrollAxis axis, int new_position) { internal_scroll(new_position, axis); });
 
-        m_search_bar.on_kill_focus([&](HWND new_focus_wnd) { on_kill_focus(new_focus_wnd); });
-        m_search_bar.on_set_focus([&](HWND old_focus_wnd) { on_set_focus(old_focus_wnd); });
+        m_search_bar.set_kill_focus_callback([&](HWND new_focus_wnd) { on_kill_focus(new_focus_wnd); });
+        m_search_bar.set_set_focus_callback([&](HWND old_focus_wnd) { on_set_focus(old_focus_wnd); });
 
-        m_search_bar.on_destroy([&] { on_size(); });
+        m_search_bar.set_destroy_callback([&] { on_size(); });
 
         // For dark mode, the window needs to have the DarkMode_Explorer theme to get dark scroll bars,
         // but we also need access to DarkMode_ItemsView themes. To do this, a dummy window with a

--- a/list_view/list_view_search.cpp
+++ b/list_view/list_view_search.cpp
@@ -125,17 +125,14 @@ void SearchBar::create(HWND parent_wnd, const char* label, HFONT font, int item_
         return;
 
     m_parent_wnd = parent_wnd;
-    m_item_height = item_height;
     m_is_dark = is_dark;
 
-    m_edit_control.reset(CreateWindowEx(WS_EX_CLIENTEDGE, WC_EDIT, L"",
-        WS_CHILD | WS_CLIPSIBLINGS | ES_LEFT | WS_CLIPCHILDREN | ES_AUTOHSCROLL | WS_TABSTOP, 0, 0, 0, 0, parent_wnd,
-        reinterpret_cast<HMENU>(IDC_SEARCH_BAR_EDIT), wil::GetModuleInstanceHandle(), nullptr));
+    m_edit_control.reset(CreateWindowEx(0, WC_EDIT, L"",
+        WS_CHILD | WS_CLIPSIBLINGS | ES_LEFT | WS_CLIPCHILDREN | ES_AUTOHSCROLL | WS_TABSTOP | WS_BORDER, 0, 0, 0, 0,
+        parent_wnd, reinterpret_cast<HMENU>(IDC_SEARCH_BAR_EDIT), wil::GetModuleInstanceHandle(), nullptr));
 
     if (!m_edit_control)
         return;
-
-    m_search_label = label;
 
     enhance_edit_control(m_edit_control.get());
 
@@ -143,10 +140,10 @@ void SearchBar::create(HWND parent_wnd, const char* label, HFONT font, int item_
         m_edit_control.get(), [&](auto wnd_proc, auto wnd, auto msg, auto wp, auto lp) -> std::optional<LRESULT> {
             switch (msg) {
             case WM_KILLFOCUS:
-                m_on_kill_focus(reinterpret_cast<HWND>(wp));
+                m_on_kill_focus_func(reinterpret_cast<HWND>(wp));
                 break;
             case WM_SETFOCUS:
-                m_on_set_focus(reinterpret_cast<HWND>(wp));
+                m_on_set_focus_func(reinterpret_cast<HWND>(wp));
                 break;
             case WM_KEYDOWN:
                 m_prevent_wm_char_processing = false;
@@ -189,8 +186,8 @@ void SearchBar::create(HWND parent_wnd, const char* label, HFONT font, int item_
             return {};
         });
 
-    SendMessage(m_edit_control.get(), WM_SETFONT, (WPARAM)font, MAKELONG(TRUE, 0));
-    SetWindowTheme(m_edit_control.get(), is_dark ? L"DarkMode_CFD" : nullptr, nullptr);
+    set_font(font);
+    SetWindowTheme(m_edit_control.get(), is_dark ? L"DarkMode_Explorer" : nullptr, nullptr);
 
     Edit_SetCueBannerTextFocused(m_edit_control.get(), mmh::to_utf16(label).c_str(), true);
 
@@ -229,23 +226,21 @@ void SearchBar::destroy()
     invalidate();
 
     m_edit_control.reset();
-    m_search_label.reset();
     m_left_toolbar.wnd.reset();
     m_right_toolbar.wnd.reset();
     m_search_bar_host->on_close();
 
-    m_on_destroy();
+    m_on_destroy_func();
 }
 
 void SearchBar::shut_down()
 {
     m_edit_control.reset();
-    m_search_label.reset();
     m_left_toolbar.wnd.reset();
     m_right_toolbar.wnd.reset();
     m_left_toolbar.imagelist.reset();
     m_right_toolbar.imagelist.reset();
-    m_on_destroy = {};
+    m_on_destroy_func = {};
 }
 
 SearchBar::Metrics SearchBar::get_metrics() const
@@ -269,6 +264,13 @@ int SearchBar::get_total_height() const
     return get_metrics().total_height;
 }
 
+void SearchBar::reposition() const
+{
+    RECT client_rect{};
+    GetClientRect(m_parent_wnd, &client_rect);
+    reposition(wil::rect_width(client_rect), wil::rect_height(client_rect));
+}
+
 void SearchBar::reposition(int client_width, int client_height) const
 {
     const auto vertical_padding = get_vertical_padding();
@@ -276,16 +278,15 @@ void SearchBar::reposition(int client_width, int client_height) const
     const auto max_edit_width = 300_spx;
     const auto edit_width = std::clamp(
         client_width - 2 * horizontal_padding - m_left_toolbar.width - m_right_toolbar.width, 0, max_edit_width);
-    const auto edit_height = m_edit_control ? m_item_height + horizontal_padding : 0;
-    const auto total_height = std::max(edit_height, m_right_toolbar.height) + vertical_padding * 2;
+    const auto total_height = std::max(m_edit_height, m_right_toolbar.height) + vertical_padding * 2;
     bool should_invalidate{};
 
     if (m_edit_control) {
         RECT old_edit_rect{};
         GetWindowRect(m_edit_control.get(), &old_edit_rect);
 
-        SetWindowPos(m_edit_control.get(), nullptr, 0, client_height - (total_height + edit_height) / 2, edit_width,
-            edit_height, SWP_NOZORDER);
+        SetWindowPos(m_edit_control.get(), nullptr, 0, client_height - (total_height + m_edit_height) / 2, edit_width,
+            m_edit_height, SWP_NOZORDER);
 
         should_invalidate = wil::rect_width(old_edit_rect) != edit_width;
     }
@@ -324,7 +325,7 @@ void SearchBar::set_use_dark_mode(bool is_dark)
     m_is_dark = is_dark;
 
     if (m_edit_control)
-        SetWindowTheme(m_edit_control.get(), is_dark ? L"DarkMode_CFD" : nullptr, nullptr);
+        SetWindowTheme(m_edit_control.get(), is_dark ? L"DarkMode_Explorer" : nullptr, nullptr);
 
     m_left_toolbar.imagelist.reset();
     m_right_toolbar.imagelist.reset();
@@ -347,6 +348,15 @@ void SearchBar::set_use_dark_mode(bool is_dark)
 
     if (m_right_toolbar.wnd)
         set_toolbar_dark_mode(m_right_toolbar, right_commands);
+}
+
+void SearchBar::set_font(HFONT font)
+{
+    if (!m_edit_control.get())
+        return;
+
+    m_edit_height = get_font_height(font) + 2 * 3_spx;
+    SetWindowFont(m_edit_control.get(), font, FALSE);
 }
 
 void SearchBar::set_results_text(std::wstring_view new_text)

--- a/list_view/list_view_search.h
+++ b/list_view/list_view_search.h
@@ -56,9 +56,9 @@ public:
     void focus() const { SetFocus(m_edit_control.get()); }
     void select_all() const { SendMessage(m_edit_control.get(), EM_SETSEL, 0, -1); }
 
-    void on_destroy(OnDestroyCallback on_destroy) { m_on_destroy = std::move(on_destroy); }
-    void on_kill_focus(OnFocusCallback on_kill_focus) { m_on_kill_focus = std::move(on_kill_focus); }
-    void on_set_focus(OnFocusCallback on_set_focus) { m_on_set_focus = std::move(on_set_focus); }
+    void set_destroy_callback(OnDestroyCallback on_destroy) { m_on_destroy_func = std::move(on_destroy); }
+    void set_kill_focus_callback(OnFocusCallback on_kill_focus) { m_on_kill_focus_func = std::move(on_kill_focus); }
+    void set_set_focus_callback(OnFocusCallback on_set_focus) { m_on_set_focus_func = std::move(on_set_focus); }
 
     struct Metrics {
         int edit_width{};
@@ -70,6 +70,7 @@ public:
     [[nodiscard]] int get_total_height() const;
     [[nodiscard]] HWND get_edit_wnd() const { return m_edit_control.get(); }
 
+    void reposition() const;
     void reposition(int client_width, int client_height) const;
 
     void previous() const
@@ -87,6 +88,7 @@ public:
     void on_string_change();
 
     void set_use_dark_mode(bool is_dark);
+    void set_font(HFONT font);
 
     void set_results_text(std::wstring_view new_text);
     void invalidate() const;
@@ -104,13 +106,13 @@ private:
     HWND m_parent_wnd{};
     bool m_is_dark{};
     pfc::string8 m_search_label;
-    int m_item_height{};
+    int m_edit_height{};
     std::wstring m_results_text;
     SearchBarHost::Ptr m_search_bar_host;
     std::wstring m_last_string{};
-    OnDestroyCallback m_on_destroy;
-    OnFocusCallback m_on_set_focus;
-    OnFocusCallback m_on_kill_focus;
+    OnDestroyCallback m_on_destroy_func;
+    OnFocusCallback m_on_set_focus_func;
+    OnFocusCallback m_on_kill_focus_func;
 };
 
 } // namespace uih::lv


### PR DESCRIPTION
This makes a few small tweaks to the list view search bar.

It:
- makes the edit control use the same border style as the inline editing edit control
- makes the search bar update correctly when the list view item font changes
- stops using the vertical item padding when calculating the edit control height, as the text in a single-line edit control cannot be vertically centred
