### PR TITLE
Migrate to Visual Studio 2026

### DIFF
--- a/literals.cpp
+++ b/literals.cpp
@@ -2,7 +2,7 @@
 
 namespace uih::literals::spx {
 
-int operator"" _spx(unsigned long long px)
+int operator""_spx(unsigned long long px)
 {
     return scale_dpi_value(gsl::narrow<int>(px));
 }

--- a/literals.h
+++ b/literals.h
@@ -2,6 +2,6 @@
 
 namespace uih::literals::spx {
 
-int operator"" _spx(unsigned long long px);
+int operator""_spx(unsigned long long px);
 
 }

--- a/ui_helpers.vcxproj
+++ b/ui_helpers.vcxproj
@@ -29,24 +29,24 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
This migrates to Visual Studio 2026 and the v14.50 toolset.