### PR TITLE
Allow overriding handling of edit control keydown messages

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -919,6 +919,8 @@ private:
 
     virtual void notify_exit_inline_edit() {}
 
+    virtual bool notify_inline_edit_keydown(WPARAM wp) { return false; }
+
     int get_items_viewport_height() const;
     void update_vertical_scroll_info(bool redraw = true, std::optional<int> new_vertical_position = std::nullopt);
     void update_horizontal_scroll_info(bool redraw = true);
@@ -1004,6 +1006,8 @@ private:
     bool m_timer_inline_edit{false};
     bool m_inline_edit_prevent{false};
     bool m_inline_edit_prevent_kill{false};
+    bool m_ignore_next_inline_edit_wm_char_message{};
+    bool m_ignore_next_inline_edit_wm_syschar_message{};
     size_t m_inline_edit_column{std::numeric_limits<size_t>::max()};
     pfc::list_t<size_t> m_inline_edit_indices;
     wil::com_ptr<IAutoComplete> m_inline_edit_autocomplete;
@@ -1060,7 +1064,8 @@ private:
 
     bool m_variable_height_items{false};
 
-    bool m_prevent_wm_char_processing{false};
+    bool m_ignore_next_wm_char_message{};
+    bool m_ignore_next_wm_syschar_message{};
     bool m_timer_search{false};
     std::wstring m_search_string;
 

--- a/list_view/list_view_inline_edit.cpp
+++ b/list_view/list_view_inline_edit.cpp
@@ -118,7 +118,25 @@ LRESULT ListView::on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM l
         break;
     case WM_GETDLGCODE:
         return CallWindowProc(m_proc_inline_edit, wnd, msg, wp, lp) | DLGC_WANTALLKEYS;
+    case WM_CHAR:
+        if (m_ignore_next_inline_edit_wm_char_message) {
+            m_ignore_next_inline_edit_wm_char_message = false;
+            return 0;
+        }
+        break;
+    case WM_SYSCHAR:
+        if (m_ignore_next_inline_edit_wm_syschar_message) {
+            m_ignore_next_inline_edit_wm_syschar_message = false;
+            return 0;
+        }
+        break;
+    case WM_SYSKEYDOWN:
+        if ((m_ignore_next_inline_edit_wm_syschar_message = notify_inline_edit_keydown(wp)))
+            return 0;
+        break;
     case WM_KEYDOWN:
+        m_ignore_next_inline_edit_wm_char_message = false;
+
         switch (wp) {
         case VK_TAB: {
             size_t count = m_columns.size();
@@ -200,6 +218,11 @@ LRESULT ListView::on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM l
             // else
             //    return CallWindowProc(m_proc_original_inline_edit,wnd,msg,wp,lp); //cheat
             return 0;
+        default:
+            if (notify_inline_edit_keydown(wp)) {
+                m_ignore_next_inline_edit_wm_char_message = true;
+                return 0;
+            }
         }
         break;
     }

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -540,18 +540,26 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         }
         break;
     case WM_KEYDOWN: {
-        if ((m_prevent_wm_char_processing = on_wm_keydown(wp, lp)))
+        if ((m_ignore_next_wm_char_message = on_wm_keydown(wp, lp)))
             return 0;
-    } break;
+        break;
+    }
     case WM_CHAR:
         // Values below 32, and 127, are special values (e.g. Ctrl-A and Ctrl-Backspace)
-        if (!m_prevent_wm_char_processing && wp >= 32u && wp != 127u)
+        if (!m_ignore_next_wm_char_message && wp >= 32u && wp != 127u)
             on_search_string_change(LOWORD(wp));
         break;
     case WM_SYSKEYDOWN: {
-        if ((m_prevent_wm_char_processing = notify_on_keyboard_keydown_filter(WM_SYSKEYDOWN, wp, lp)))
+        if ((m_ignore_next_wm_syschar_message = notify_on_keyboard_keydown_filter(WM_SYSKEYDOWN, wp, lp)))
             return 0;
-    } break;
+        break;
+    }
+    case WM_SYSCHAR:
+        if (m_ignore_next_wm_syschar_message) {
+            m_ignore_next_wm_syschar_message = false;
+            return 0;
+        }
+        break;
     case WM_VSCROLL:
         // IDropTargetHelper inexplicably sends these messages. They aren't processed to
         // avoid interfering with the timer usually used by clients.

--- a/list_view/list_view_search.cpp
+++ b/list_view/list_view_search.cpp
@@ -146,7 +146,7 @@ void SearchBar::create(HWND parent_wnd, const char* label, HFONT font, int item_
                 m_on_set_focus_func(reinterpret_cast<HWND>(wp));
                 break;
             case WM_KEYDOWN:
-                m_prevent_wm_char_processing = false;
+                m_ignore_next_wm_char_message = false;
 
                 switch (wp) {
                 case VK_TAB:
@@ -168,17 +168,30 @@ void SearchBar::create(HWND parent_wnd, const char* label, HFONT font, int item_
                         m_search_bar_host->on_next();
                     return 0;
                 case VK_RETURN:
-                    m_prevent_wm_char_processing = true;
+                    m_ignore_next_wm_char_message = true;
                     m_search_bar_host->on_return();
                     return 0;
+                default:
+                    if (m_search_bar_host->on_keydown(wp)) {
+                        m_ignore_next_wm_char_message = true;
+                        return 0;
+                    }
+                    break;
                 }
                 break;
             case WM_SYSKEYDOWN:
-                m_prevent_wm_char_processing = false;
+                if ((m_ignore_next_wm_syschar_message = m_search_bar_host->on_keydown(wp)))
+                    return 0;
                 break;
             case WM_CHAR:
-                if (m_prevent_wm_char_processing) {
-                    m_prevent_wm_char_processing = false;
+                if (m_ignore_next_wm_char_message) {
+                    m_ignore_next_wm_char_message = false;
+                    return 0;
+                }
+                return {};
+            case WM_SYSCHAR:
+                if (m_ignore_next_wm_syschar_message) {
+                    m_ignore_next_wm_syschar_message = false;
                     return 0;
                 }
                 return {};

--- a/list_view/list_view_search.h
+++ b/list_view/list_view_search.h
@@ -28,6 +28,7 @@ struct SearchBarHost {
     virtual void on_char(const wchar_t chr) {}
     virtual void on_string_replaced(const wchar_t* text) {}
     virtual void on_close() {}
+    virtual bool on_keydown(WPARAM wp) { return false; }
     virtual std::variant<wil::unique_hbitmap, wil::unique_hicon> create_icon(
         SearchBarIconId icon_id, int width, int height, bool is_dark) = 0;
 
@@ -100,7 +101,8 @@ private:
     static int get_vertical_padding();
 
     wil::unique_hwnd m_edit_control;
-    bool m_prevent_wm_char_processing{};
+    bool m_ignore_next_wm_char_message{};
+    bool m_ignore_next_wm_syschar_message{};
     SearchBarToolbarState m_left_toolbar;
     SearchBarToolbarState m_right_toolbar;
     HWND m_parent_wnd{};


### PR DESCRIPTION
This adds a way to override the handling of WM_KEYDOWN and WM_SYSKEYDOWN messages to edit controls used in list view inline editing and the list view search bar.

This is intended for the processing of application keyboard shortcuts.

This also makes the list view itself ignore a WM_SYSCHAR message if the preceding WM_SYSKEYDOWN message was handled. This is to avoid triggering both a keyboard accelerator and a custom keyboard shortcut when there is a conflict.