### PR TITLE
Flag restored search string in list view search bar

### DIFF
--- a/list_view/list_view_search.cpp
+++ b/list_view/list_view_search.cpp
@@ -127,6 +127,10 @@ void SearchBar::create(HWND parent_wnd, const char* label, HFONT font, int item_
     m_parent_wnd = parent_wnd;
     m_is_dark = is_dark;
 
+    m_is_initialising = true;
+
+    auto _ = wil::scope_exit([&] { m_is_initialising = false; });
+
     m_edit_control.reset(CreateWindowEx(0, WC_EDIT, L"",
         WS_CHILD | WS_CLIPSIBLINGS | ES_LEFT | WS_CLIPCHILDREN | ES_AUTOHSCROLL | WS_TABSTOP | WS_BORDER, 0, 0, 0, 0,
         parent_wnd, reinterpret_cast<HMENU>(IDC_SEARCH_BAR_EDIT), wil::GetModuleInstanceHandle(), nullptr));
@@ -321,11 +325,11 @@ void SearchBar::on_string_change()
 {
     const auto new_string = get_window_text(m_edit_control.get());
 
-    if (new_string.size() == m_last_string.size() + 1
+    if (!m_is_initialising && new_string.size() == m_last_string.size() + 1
         && wcsncmp(m_last_string.c_str(), new_string.c_str(), m_last_string.size()) == 0)
         m_search_bar_host->on_char(gsl::narrow<wchar_t>(new_string[new_string.size() - 1]));
     else
-        m_search_bar_host->on_string_replaced(new_string.c_str());
+        m_search_bar_host->on_string_replaced(new_string.c_str(), m_is_initialising);
 
     m_last_string = new_string;
 }

--- a/list_view/list_view_search.h
+++ b/list_view/list_view_search.h
@@ -26,7 +26,7 @@ struct SearchBarHost {
     virtual void on_next() = 0;
     virtual void on_return() = 0;
     virtual void on_char(const wchar_t chr) {}
-    virtual void on_string_replaced(const wchar_t* text) {}
+    virtual void on_string_replaced(const wchar_t* text, bool is_initial) {}
     virtual void on_close() {}
     virtual bool on_keydown(WPARAM wp) { return false; }
     virtual std::variant<wil::unique_hbitmap, wil::unique_hicon> create_icon(
@@ -100,6 +100,7 @@ private:
     static int get_horizontal_padding();
     static int get_vertical_padding();
 
+    bool m_is_initialising{};
     wil::unique_hwnd m_edit_control;
     bool m_ignore_next_wm_char_message{};
     bool m_ignore_next_wm_syschar_message{};


### PR DESCRIPTION
This makes the list view search bar flag whether a search string was restored from a previous search bar instance when calling `SearchBarHost::on_string_replaced()`.