### PR TITLE
Select all on Ctrl+F in list view search box

### DIFF
--- a/list_view/list_view_keyboard.cpp
+++ b/list_view/list_view_keyboard.cpp
@@ -13,7 +13,13 @@ bool ListView::on_wm_keydown(WPARAM wp, LPARAM lp)
 
     const auto is_alt_down = (HIWORD(lp) & KF_ALTDOWN) != 0;
     const auto is_ctrl_down = (GetKeyState(VK_CONTROL) & KF_UP) != 0;
-    const auto process_ctrl_char_shortcuts = is_ctrl_down && !is_alt_down;
+
+    const auto should_process_ctrl_shortcuts = [&] {
+        const auto is_shift_down = (GetKeyState(VK_SHIFT) & KF_UP) != 0;
+        const auto is_lwin_down = (GetKeyState(VK_LWIN) & KF_UP) != 0;
+        const auto is_rwin_down = (GetKeyState(VK_RWIN) & KF_UP) != 0;
+        return is_ctrl_down && !(is_alt_down || is_shift_down || is_lwin_down || is_rwin_down);
+    };
 
     switch (wp) {
     case VK_TAB:
@@ -65,23 +71,23 @@ bool ListView::on_wm_keydown(WPARAM wp, LPARAM lp)
         }
         return notify_on_keyboard_keydown_search();
     case 'A':
-        if (process_ctrl_char_shortcuts && m_selection_mode == SelectionMode::Multiple) {
+        if (should_process_ctrl_shortcuts() && m_selection_mode == SelectionMode::Multiple) {
             set_selection_state(pfc::bit_array_true(), pfc::bit_array_true());
             return true;
         }
         return false;
     case 'C':
-        return process_ctrl_char_shortcuts && notify_on_keyboard_keydown_copy();
+        return should_process_ctrl_shortcuts() && notify_on_keyboard_keydown_copy();
     case 'F':
-        return process_ctrl_char_shortcuts && notify_on_keyboard_keydown_search();
+        return should_process_ctrl_shortcuts() && notify_on_keyboard_keydown_search();
     case 'V':
-        return process_ctrl_char_shortcuts && notify_on_keyboard_keydown_paste();
+        return should_process_ctrl_shortcuts() && notify_on_keyboard_keydown_paste();
     case 'X':
-        return process_ctrl_char_shortcuts && notify_on_keyboard_keydown_cut();
+        return should_process_ctrl_shortcuts() && notify_on_keyboard_keydown_cut();
     case 'Y':
-        return process_ctrl_char_shortcuts && notify_on_keyboard_keydown_redo();
+        return should_process_ctrl_shortcuts() && notify_on_keyboard_keydown_redo();
     case 'Z':
-        return process_ctrl_char_shortcuts && notify_on_keyboard_keydown_undo();
+        return should_process_ctrl_shortcuts() && notify_on_keyboard_keydown_undo();
     default:
         return false;
     }

--- a/list_view/list_view_search.cpp
+++ b/list_view/list_view_search.cpp
@@ -175,6 +175,21 @@ void SearchBar::create(HWND parent_wnd, const char* label, HFONT font, int item_
                     m_ignore_next_wm_char_message = true;
                     m_search_bar_host->on_return();
                     return 0;
+                case 'F': {
+                    const auto is_alt_down = (HIWORD(lp) & KF_ALTDOWN) != 0;
+                    const auto is_ctrl_down = (GetKeyState(VK_CONTROL) & KF_UP) != 0;
+                    const auto is_shift_down = (GetKeyState(VK_SHIFT) & KF_UP) != 0;
+                    const auto is_lwin_down = (GetKeyState(VK_LWIN) & KF_UP) != 0;
+                    const auto is_rwin_down = (GetKeyState(VK_RWIN) & KF_UP) != 0;
+
+                    if (is_ctrl_down && !(is_alt_down || is_shift_down || is_lwin_down || is_rwin_down)) {
+                        m_ignore_next_wm_char_message = true;
+                        select_all();
+                        return 0;
+                    }
+
+                    break;
+                }
                 default:
                     if (m_search_bar_host->on_keydown(wp)) {
                         m_ignore_next_wm_char_message = true;


### PR DESCRIPTION
This makes the list view search bar edit control select all text in the control if Ctrl+F is pressed while the edit control is focused. This takes precedence over any custom handling of Ctrl+F by the list view host.

Additionally, other list view keyboard shortcuts involving the Ctrl key no longer trigger if Shift or the Windows keys are also held down.