### PR TITLE
Add invalidate parameter to ListView::update_items()

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -373,7 +373,7 @@ public:
         size_t index, const std::optional<RECT>& items_rect = {}, std::optional<int> scroll_position = {});
     void invalidate_item_group_info_area(size_t index);
 
-    void update_items(size_t index, size_t count);
+    void update_items(size_t index, size_t count, bool invalidate = true);
     void update_all_items();
 
     // Current implementation clears sub-items.

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -481,12 +481,13 @@ void ListView::invalidate_all(bool b_children, bool non_client)
     RedrawWindow(get_wnd(), invalidate_rect ? &*invalidate_rect : nullptr, nullptr, flags);
 }
 
-void ListView::update_items(size_t index, size_t count)
+void ListView::update_items(size_t index, size_t count, bool invalidate)
 {
-    size_t i;
-    for (i = 0; i < count; i++)
+    for (size_t i{}; i < count; ++i)
         m_items[i + index]->m_subitems.resize(0);
-    invalidate_items(index, count);
+
+    if (invalidate)
+        invalidate_items(index, count);
 }
 
 void ListView::reorder_items_partial(size_t base, const size_t* order, size_t count, bool update_focus_item)


### PR DESCRIPTION
This adds a parameter to the `ListView::update_items()` method to control whether the relevant items are invalidated using `RedrawWindow()`.