### PR TITLE
Indent list view items using maximum visible grouping level

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -126,7 +126,11 @@ public:
         void remove_items(const pfc::bit_array& mask);
 
     private:
-        ItemTransaction(ListView& list_view) : m_list_view(list_view) {}
+        ItemTransaction(ListView& list_view)
+            : m_list_view(list_view)
+            , m_saved_scroll_position(list_view.save_scroll_position())
+        {
+        }
 
         ItemTransaction(const ItemTransaction&) = delete;
         ItemTransaction& operator=(const ItemTransaction&) = delete;
@@ -136,6 +140,7 @@ public:
 
         std::optional<size_t> m_start_index;
         ListView& m_list_view;
+        lv::SavedScrollPosition m_saved_scroll_position;
 
         friend class ListView;
     };
@@ -244,7 +249,7 @@ public:
     size_t get_column_count();
 
     lv::SavedScrollPosition save_scroll_position() const;
-    void restore_scroll_position(const lv::SavedScrollPosition& position);
+    void restore_scroll_position(const lv::SavedScrollPosition& position, bool redraw_scroll_bars = true);
 
     void _set_scroll_position(int val) { m_scroll_position = val; }
 
@@ -467,7 +472,7 @@ public:
 
     int get_group_minimum_inner_height() const
     {
-        return get_show_group_info_area() ? get_group_info_area_total_height() : 0;
+        return get_show_group_info_area() && m_visible_group_count > 0 ? get_group_info_area_total_height() : 0;
     }
     int get_group_items_bottom_margin(size_t index) const;
     int get_leaf_group_header_bottom_margin(std::optional<size_t> index = {}) const;
@@ -489,7 +494,7 @@ public:
 
         int ret = get_item_position(index) + m_item_height - 1;
 
-        if (get_show_group_info_area() && m_group_count > 0) {
+        if (get_show_group_info_area() && m_visible_group_count > 0) {
             int gheight = gsl::narrow<int>(group_size) * m_item_height;
             int group_cy = get_group_info_area_total_height();
             const auto bottom_margin = get_group_items_bottom_margin(index);
@@ -778,7 +783,7 @@ protected:
         return header_item_index - 1;
     }
 
-    bool get_show_group_info_area() const { return m_group_count ? m_show_group_info_area : false; }
+    bool get_show_group_info_area() const { return m_group_count > 0 ? m_show_group_info_area : false; }
 
     int get_total_indentation() const;
     [[nodiscard]] int get_stuck_group_headers_height(std::optional<int> scroll_position = {}) const;
@@ -944,6 +949,9 @@ private:
     void remove_item_in_internal_state(size_t remove_index);
     void remove_items_in_internal_state(const pfc::bit_array& mask);
     void calculate_item_positions(size_t index_start = 0);
+    void calculate_visible_group_count();
+    bool update_item_and_group_positioning(size_t index_start = 0);
+    bool are_group_headers_sticky_active() const { return m_are_group_headers_sticky && m_visible_group_count > 0; }
 
     static LRESULT WINAPI s_on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
     LRESULT on_inline_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
@@ -1040,7 +1048,8 @@ private:
     bool m_is_smooth_scrolling_suspended{};
     std::optional<SmoothScrollHelper> m_smooth_scroll_helper;
     bool m_ensure_visible_suspended{};
-    size_t m_group_count{0};
+    size_t m_group_count{};
+    size_t m_visible_group_count{};
     int m_item_height{1};
     int m_group_height{1};
     bool m_are_group_headers_sticky{};

--- a/list_view/list_view_header.cpp
+++ b/list_view/list_view_header.cpp
@@ -324,19 +324,32 @@ int ListView::calculate_header_height()
 
 void ListView::update_header()
 {
-    if (m_wnd_header) {
-        pfc::vartoggle_t<bool> toggle(m_ignore_column_size_change_notification, true);
-        auto count = gsl::narrow<int>(m_columns.size());
-        int j = 0;
-        if (m_have_indent_column) {
-            uih::header_set_item_width(m_wnd_header, j, get_total_indentation());
-            j++;
+    if (!m_wnd_header)
+        return;
+
+    pfc::vartoggle_t<bool> toggle(m_ignore_column_size_change_notification, true);
+
+    const auto indentation = get_total_indentation();
+    const auto need_indentation_column = indentation > 0;
+
+    if (m_have_indent_column != need_indentation_column) {
+        if (!need_indentation_column) {
+            Header_DeleteItem(m_wnd_header, 0);
+        } else {
+            HDITEM hdi{};
+            hdi.mask = HDI_WIDTH;
+            hdi.cxy = indentation;
+            Header_InsertItem(m_wnd_header, 0, &hdi);
         }
-        for (int i = 0; i < count; i++) {
-            uih::header_set_item_width(m_wnd_header, i + j, m_columns[i].m_display_size);
-        }
-        // SendMessage(m_wnd_header, WM_SETREDRAW, TRUE, NULL);
-        // RedrawWindow(m_wnd_header, NULL, NULL, RDW_INVALIDATE|(b_update?RDW_UPDATENOW:0));
+        m_have_indent_column = need_indentation_column;
+    } else if (m_have_indent_column) {
+        header_set_item_width(m_wnd_header, 0, indentation);
+    }
+
+    auto count = gsl::narrow<int>(m_columns.size());
+
+    for (int index{}; index < count; index++) {
+        header_set_item_width(m_wnd_header, index + (m_have_indent_column ? 1 : 0), m_columns[index].m_display_size);
     }
 }
 

--- a/list_view/list_view_hittest.cpp
+++ b/list_view/list_view_hittest.cpp
@@ -236,8 +236,7 @@ ListView::VerticalHitTestResult ListView::visible_items_vertical_hit_test(int y)
 {
     const auto result = underlying_items_vertical_hit_test(y);
 
-    if (!m_are_group_headers_sticky || m_group_count == 0
-        || result.position_category == VerticalPositionCategory::NoItems)
+    if (!are_group_headers_sticky_active() || result.position_category == VerticalPositionCategory::NoItems)
         return result;
 
     const auto first_item = underlying_items_vertical_hit_test(m_scroll_position).item_leftmost;

--- a/list_view/list_view_items.cpp
+++ b/list_view/list_view_items.cpp
@@ -92,8 +92,11 @@ ListView::ItemTransaction::~ItemTransaction() noexcept
     if (!m_start_index)
         return;
 
-    m_list_view.calculate_item_positions(*m_start_index);
-    m_list_view.update_scroll_info(true, true, false);
+    if (m_list_view.update_item_and_group_positioning(*m_start_index))
+        m_list_view.restore_scroll_position(m_saved_scroll_position, false);
+    else
+        m_list_view.update_scroll_info(true, true, false);
+
     m_list_view.invalidate_all(false, true);
 }
 
@@ -117,15 +120,19 @@ ListView::ItemTransaction ListView::start_transaction()
 void ListView::insert_items(size_t index_start, size_t count, const InsertItem* items,
     const std::optional<lv::SavedScrollPosition>& saved_scroll_position)
 {
+    const auto grouping_saved_scroll_position
+        = saved_scroll_position ? saved_scroll_position : std::make_optional(save_scroll_position());
     insert_items_in_internal_state(index_start, count, items);
-    calculate_item_positions(index_start);
+    update_item_and_group_positioning(index_start);
 
-    if (saved_scroll_position)
-        restore_scroll_position(*saved_scroll_position);
+    if (update_item_and_group_positioning(index_start))
+        restore_scroll_position(*grouping_saved_scroll_position);
+    else if (saved_scroll_position)
+        restore_scroll_position(*grouping_saved_scroll_position);
     else
         update_scroll_info();
 
-    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
+    invalidate_all();
 }
 
 bool ListView::replace_items(size_t index_start, size_t count, const InsertItem* items)
@@ -135,10 +142,13 @@ bool ListView::replace_items(size_t index_start, size_t count, const InsertItem*
     if (count == 0)
         return false;
 
+    const auto grouping_saved_scroll_position = save_scroll_position();
     const auto subsequent_display_indices_changed = replace_items_in_internal_state(index_start, count, items);
-    calculate_item_positions(index_start);
 
-    if (m_group_count > 0 || m_variable_height_items) {
+    if (update_item_and_group_positioning(index_start)) {
+        restore_scroll_position(grouping_saved_scroll_position);
+        invalidate_all();
+    } else if (m_visible_group_count > 0 || m_variable_height_items) {
         update_scroll_info();
         invalidate_all();
     } else {
@@ -150,10 +160,15 @@ bool ListView::replace_items(size_t index_start, size_t count, const InsertItem*
 
 void ListView::remove_items(const pfc::bit_array& mask)
 {
+    const auto grouping_saved_scroll_position = save_scroll_position();
     remove_items_in_internal_state(mask);
-    calculate_item_positions();
-    update_scroll_info();
-    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
+
+    if (update_item_and_group_positioning())
+        restore_scroll_position(grouping_saved_scroll_position);
+    else
+        update_scroll_info();
+
+    invalidate_all();
 }
 
 void ListView::remove_all_items()
@@ -164,7 +179,7 @@ void ListView::remove_all_items()
     m_items.clear();
     update_scroll_info();
 
-    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
+    invalidate_all();
 }
 
 bool ListView::replace_items_in_internal_state(size_t index_start, size_t replace_count, const InsertItem* items)
@@ -433,20 +448,27 @@ void ListView::calculate_item_positions(size_t index_start)
         return;
 
     int y_pointer = 0;
-    if (m_group_count)
-        while (index_start && !get_is_new_group(index_start))
-            index_start--;
-    if (!index_start)
-        y_pointer += 0; // m_item_height * m_group_count;
-    else {
-        if (m_group_count)
+
+    if (m_group_count > 0) {
+        if (m_visible_group_count == 0) {
+            index_start = 0;
+        } else {
+            while (index_start > 0 && !get_is_new_group(index_start))
+                --index_start;
+        }
+    }
+
+    if (index_start > 0) {
+        if (m_visible_group_count > 0)
             y_pointer = get_item_group_bottom(index_start - 1) + 1;
         else
             y_pointer = get_item_position(index_start - 1) + get_item_height(index_start - 1);
     }
+
     size_t count = m_items.size();
     int group_height_counter = 0;
     const auto group_minimum_inner_height = get_group_minimum_inner_height();
+
     for (size_t i = index_start; i < count; i++) {
         const auto is_new_group = get_is_new_group(i);
         const auto display_group_count = gsl::narrow<int>(get_item_display_group_count(i));
@@ -472,14 +494,62 @@ void ListView::calculate_item_positions(size_t index_start)
     }
 }
 
+void ListView::calculate_visible_group_count()
+{
+    if (m_group_count == 0 || m_items.empty()) {
+        m_visible_group_count = 0;
+        return;
+    }
+
+    m_visible_group_count = 0;
+
+    for (const auto index : std::views::iota(size_t{}, m_items.size())) {
+        if (!get_is_new_group(index))
+            continue;
+
+        m_visible_group_count = std::max(m_visible_group_count,
+            ranges::accumulate(m_items[index]->m_groups, size_t{}, std::plus<size_t>(),
+                [](const auto& group) { return group->is_hidden() ? size_t{} : size_t{1}; }));
+
+        if (m_visible_group_count == m_group_count)
+            return;
+    }
+
+    assert(m_visible_group_count <= m_group_count);
+}
+
+bool ListView::update_item_and_group_positioning(size_t index_start)
+{
+    const auto old_visible_group_count = m_visible_group_count;
+    calculate_visible_group_count();
+
+    const auto has_vertical_padding_changed
+        = std::min(size_t{2}, old_visible_group_count) != std::min(size_t{2}, m_visible_group_count);
+    calculate_item_positions(has_vertical_padding_changed ? 0 : index_start);
+
+    if (old_visible_group_count != m_visible_group_count) {
+        update_column_sizes();
+        update_header();
+        return true;
+    }
+
+    return false;
+}
+
 void ListView::remove_item(size_t index)
 {
     if (m_timer_inline_edit)
         exit_inline_edit();
+
+    const auto grouping_saved_scroll_position = save_scroll_position();
     remove_item_in_internal_state(index);
-    calculate_item_positions();
-    update_scroll_info();
-    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
+
+    if (update_item_and_group_positioning())
+        restore_scroll_position(grouping_saved_scroll_position);
+    else
+        update_scroll_info();
+
+    invalidate_all();
 }
 
 void ListView::remove_items_in_internal_state(const pfc::bit_array& mask)

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -16,7 +16,8 @@ void ListView::on_first_show()
 
 int ListView::get_group_items_bottom_margin(size_t index) const
 {
-    if (!get_show_group_info_area() || !m_is_group_info_area_header_spacing_enabled || index + 1 == m_items.size())
+    if (!get_show_group_info_area() || !m_is_group_info_area_header_spacing_enabled || m_visible_group_count == 0
+        || index + 1 == m_items.size())
         return 0;
 
     return m_group_height / 6;
@@ -24,16 +25,16 @@ int ListView::get_group_items_bottom_margin(size_t index) const
 
 int ListView::get_leaf_group_header_bottom_margin(std::optional<size_t> index) const
 {
-    if (!get_show_group_info_area() || !m_is_group_info_area_header_spacing_enabled)
+    if (!get_show_group_info_area() || !m_is_group_info_area_header_spacing_enabled || m_visible_group_count == 0)
         return 0;
 
     if (index && !get_is_new_group(*index))
         return 0;
 
     if (m_group_level_indentation_enabled)
-        return m_group_count > 1 ? m_group_height / 4 : m_group_height / 8;
+        return m_visible_group_count > 1 ? m_group_height / 4 : m_group_height / 8;
 
-    return m_group_count > 1 ? m_group_height / 5 : m_group_height / 8;
+    return m_visible_group_count > 1 ? m_group_height / 5 : m_group_height / 8;
 }
 
 int ListView::get_stuck_leaf_group_header_bottom_margin() const
@@ -43,7 +44,7 @@ int ListView::get_stuck_leaf_group_header_bottom_margin() const
 
 ListView::GroupInfoAreaPadding ListView::get_group_info_area_padding() const
 {
-    if (!get_show_group_info_area())
+    if (!get_show_group_info_area() || m_visible_group_count == 0)
         return {};
 
     const auto min_left_padding = 2_spx + 3_spx;
@@ -52,7 +53,7 @@ ListView::GroupInfoAreaPadding ListView::get_group_info_area_padding() const
     const auto indentation_step = get_indentation_step();
 
     return GroupInfoAreaPadding{
-        std::max(min_left_padding, m_group_count > 1 ? indentation_step : 0),
+        std::max(min_left_padding, m_visible_group_count > 1 ? indentation_step : 0),
         0,
         std::max(min_right_padding, indentation_step),
         std::max(min_bottom_padding, indentation_step),
@@ -61,11 +62,11 @@ ListView::GroupInfoAreaPadding ListView::get_group_info_area_padding() const
 
 int ListView::get_total_indentation() const
 {
-    if (m_group_count == 0)
+    if (m_visible_group_count == 0)
         return 0;
 
     return m_root_group_indentation_amount
-        + get_indentation_step() * gsl::narrow<int>(m_group_count - (get_show_group_info_area() ? 1 : 0))
+        + get_indentation_step() * gsl::narrow<int>(m_visible_group_count - (get_show_group_info_area() ? 1 : 0))
         + get_group_info_area_total_width();
 }
 
@@ -88,7 +89,7 @@ ListView::GroupHeaderRenderInfo ListView::get_group_header_render_info(
         - m_group_height * gsl::narrow<int>(display_group_count - display_group_index)
         - get_leaf_group_header_bottom_margin();
 
-    if (!m_are_group_headers_sticky)
+    if (!are_group_headers_sticky_active())
         return GroupHeaderRenderInfo{group_start, group_item_count, min_group_top, height, is_leaf, is_hidden, false};
 
     auto [final_leaf_group_start, final_leaf_group_item_count]
@@ -118,7 +119,7 @@ int ListView::get_stuck_group_headers_height(std::optional<int> scroll_position)
 
 ListView::StuckGroupHeadersInfo ListView::get_stuck_group_headers_info(std::optional<int> scroll_position) const
 {
-    if (!m_are_group_headers_sticky || m_group_count == 0)
+    if (!are_group_headers_sticky_active())
         return {};
 
     const auto resolved_scroll_position = scroll_position.value_or(m_scroll_position);
@@ -517,7 +518,7 @@ void ListView::invalidate_items(size_t index, size_t count) const
         return;
 
     const auto items_rect = get_items_rect();
-    const auto has_group_info_area = get_show_group_info_area();
+    const auto has_group_info_area = get_show_group_info_area() && m_visible_group_count > 0;
 
     const auto items_left
         = has_group_info_area ? get_total_indentation() - m_horizontal_scroll_position : items_rect.left;
@@ -577,7 +578,7 @@ void ListView::set_is_group_info_area_sticky(bool group_info_area_sticky)
     size_t first_item_index{};
     bool is_invalidation_needed{};
 
-    if (m_initialised && get_show_group_info_area()) {
+    if (m_initialised && get_show_group_info_area() && m_visible_group_count > 0) {
         first_item_index = gsl::narrow_cast<size_t>(get_first_or_previous_visible_item());
 
         if (first_item_index < m_items.size()) {
@@ -607,7 +608,7 @@ void ListView::set_is_group_info_area_header_spacing_enabled(bool value)
 RECT ListView::get_item_group_info_area_render_rect(
     size_t index, const std::optional<RECT>& items_rect, std::optional<int> scroll_position)
 {
-    if (!get_show_group_info_area()) {
+    if (!get_show_group_info_area() || m_visible_group_count == 0) {
         assert(false);
         return {};
     }
@@ -619,7 +620,7 @@ RECT ListView::get_item_group_info_area_render_rect(
         = get_group_header_render_info(index, m_group_count - 1, resolved_scroll_position);
 
     const auto artwork_indentation
-        = m_root_group_indentation_amount + get_indentation_step() * (gsl::narrow<int>(m_group_count) - 1);
+        = m_root_group_indentation_amount + get_indentation_step() * (gsl::narrow<int>(m_visible_group_count) - 1);
     const auto group_info_area_padding = get_group_info_area_padding();
 
     const auto [group_first_item, group_item_count] = get_item_group_range(index, m_group_count - 1);
@@ -892,8 +893,10 @@ void ListView::set_font(std::optional<direct_write::TextFormat> text_format, con
 
         refresh_items_font();
 
-        if (m_group_count)
+        if (m_visible_group_count > 0) {
+            update_column_sizes();
             update_header();
+        }
 
         if (m_search_bar) {
             m_search_bar.invalidate();

--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -97,11 +97,11 @@ void ListView::render_items(HDC dc, const RECT& paint_rect)
 
     size_t i;
     size_t count = m_items.size();
-    const auto indentation_step = m_group_count > 0 ? get_indentation_step() : 0;
+    const auto indentation_step = m_visible_group_count > 0 ? get_indentation_step() : 0;
     const auto item_indentation = get_total_indentation();
     const auto cx = get_columns_display_width() + item_indentation;
 
-    bool b_show_group_info_area = get_show_group_info_area();
+    bool b_show_group_info_area = get_show_group_info_area() && m_visible_group_count > 0;
 
     i = gsl::narrow<size_t>(get_item_at_or_before(
         (items_paint_rect.top > rc_items.top ? items_paint_rect.top - rc_items.top : 0) + m_scroll_position));
@@ -138,9 +138,9 @@ void ListView::render_items(HDC dc, const RECT& paint_rect)
 
             if (i > 0 && group == m_items[i - 1]->m_groups[group_index]) {
                 // Should be impossible for groups to be the same if one was already rendered.
-                assert(m_are_group_headers_sticky || display_group_index == 0);
+                assert(are_group_headers_sticky_active() || display_group_index == 0);
 
-                if (!(m_are_group_headers_sticky && is_first_item))
+                if (!(are_group_headers_sticky_active() && is_first_item))
                     continue;
             }
 

--- a/list_view/list_view_scroll.cpp
+++ b/list_view/list_view_scroll.cpp
@@ -27,7 +27,7 @@ lv::SavedScrollPosition ListView::save_scroll_position() const
     return {previous_item_index, next_item_index, proportional_position};
 }
 
-void ListView::restore_scroll_position(const lv::SavedScrollPosition& position)
+void ListView::restore_scroll_position(const lv::SavedScrollPosition& position, bool redraw_scroll_bars)
 {
     const auto new_next_item_bottom = get_item_position_bottom(position.next_item_index);
     const auto new_previous_item_top = get_item_position(position.previous_item_index);
@@ -36,7 +36,7 @@ void ListView::restore_scroll_position(const lv::SavedScrollPosition& position)
         + new_previous_item_top;
     const auto new_position_rounded = gsl::narrow<int>(std::lround(new_position));
 
-    update_scroll_info(true, true, true, new_position_rounded);
+    update_scroll_info(true, true, redraw_scroll_bars, new_position_rounded);
 }
 
 void ListView::ensure_visible(size_t index, EnsureVisibleMode mode)
@@ -50,7 +50,7 @@ void ListView::ensure_visible(size_t index, EnsureVisibleMode mode)
     const auto item_height = get_item_height(index);
     const auto item_start_position = get_item_position(index);
     const auto stuck_headers_height = [&] {
-        if (!m_are_group_headers_sticky || m_group_count == 0)
+        if (!are_group_headers_sticky_active())
             return 0;
 
         const auto is_new_group = get_is_new_group(index);
@@ -147,7 +147,7 @@ void ListView::internal_scroll(int new_position, ScrollAxis axis)
 
     std::vector<RECT> invalidate_after_scroll_window{};
 
-    if (m_group_count > 0 && get_show_group_info_area() && m_is_group_info_area_sticky && dy != 0) {
+    if (m_visible_group_count > 0 && get_show_group_info_area() && m_is_group_info_area_sticky && dy != 0) {
         const auto first_items
             = std::unordered_set{gsl::narrow_cast<size_t>(get_first_or_previous_visible_item(original_scroll_position)),
                 gsl::narrow_cast<size_t>(get_first_or_previous_visible_item(m_scroll_position))};
@@ -180,7 +180,7 @@ void ListView::internal_scroll(int new_position, ScrollAxis axis)
 
     RECT clip_rect{items_rect};
 
-    if (m_group_count > 0 && m_are_group_headers_sticky && dy != 0) {
+    if (are_group_headers_sticky_active() && dy != 0) {
         const auto old_stuck_group_headers_info = get_stuck_group_headers_info(original_scroll_position);
         RECT old_stuck_headers_rect{
             items_rect.left, items_rect.top, items_rect.right, items_rect.top + old_stuck_group_headers_info.height};


### PR DESCRIPTION
This makes the list view track the maximum used grouping level across all items, taking into account hidden groups. Item indentation is now calculated using this, rather than the total number of defined groups.

This means that if a grouping level is completely unused across all items, the indentation level of items is reduced.

There is no change in behaviour if a grouping level is hidden for a single group only.

Additionally, if no group headers are visible at all, then the positioning of items is adjusted as if grouping was disabled.

Lastly, a bug where columns weren’t resized correctly when changing the items font while auto-sizing columns and grouping are enabled was fixed. 