### PR TITLE
Improve focus hiding behaviour in list view

### DIFF
--- a/list_view/list_view_keyboard.cpp
+++ b/list_view/list_view_keyboard.cpp
@@ -6,7 +6,7 @@ namespace uih {
 
 bool ListView::on_wm_keydown(WPARAM wp, LPARAM lp)
 {
-    SendMessage(get_wnd(), WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), NULL);
+    show_focus_indicator_on_keydown(get_wnd(), wp);
 
     if (notify_on_keyboard_keydown_filter(WM_KEYDOWN, wp, lp))
         return true;

--- a/win32_helpers.cpp
+++ b/win32_helpers.cpp
@@ -153,41 +153,6 @@ FILETIME filetimestamp_to_FileTime(uint64_t time)
     ret.dwHighDateTime = (DWORD)(time >> 32);
     return ret;
 }
-void format_date(uint64_t time, std::basic_string<TCHAR>& str, bool b_convert_to_local)
-{
-    FILETIME ft1 = filetimestamp_to_FileTime(time);
-    FILETIME ft2 = ft1;
-    if (b_convert_to_local)
-        FileTimeToLocalFileTime2(&ft1, &ft2);
-    SYSTEMTIME st;
-    FileTimeToSystemTime(&ft2, &st);
-    int size = GetDateFormat(LOCALE_USER_DEFAULT, 0, &st, nullptr, nullptr, NULL);
-    int size2 = GetTimeFormat(LOCALE_USER_DEFAULT, 0, &st, nullptr, nullptr, NULL);
-    pfc::array_t<TCHAR> buf, buf2;
-    buf.set_size(size);
-    buf2.set_size(size2);
-    GetDateFormat(LOCALE_USER_DEFAULT, 0, &st, nullptr, buf.get_ptr(), size);
-    GetTimeFormat(LOCALE_USER_DEFAULT, 0, &st, nullptr, buf2.get_ptr(), size2);
-    str = _T("");
-    str += buf.get_ptr();
-    str += _T(" ");
-    str += buf2.get_ptr();
-}
-BOOL set_process_dpi_aware()
-{
-    using SETPROCESSDPIAWAREPROC = BOOL(WINAPI*)();
-    HINSTANCE hinstDll = LoadLibrary(_T("user32.dll"));
-
-    if (hinstDll) {
-        auto pSetProcessDPIAware = (SETPROCESSDPIAWAREPROC)GetProcAddress(hinstDll, "SetProcessDPIAware");
-
-        if (pSetProcessDPIAware) {
-            return pSetProcessDPIAware();
-        }
-    }
-
-    return FALSE;
-}
 
 SIZE get_system_dpi()
 {
@@ -251,76 +216,6 @@ int get_pointer_height()
     return 0;
 }
 
-BOOL run_action(DWORD action, NOTIFYICONDATA* data)
-{
-    if (Shell_NotifyIcon(action, data))
-        return TRUE;
-    if (action == NIM_MODIFY) {
-        if (Shell_NotifyIcon(NIM_ADD, data))
-            return TRUE;
-    }
-    return FALSE;
-}
-
-BOOL shell_notify_icon(DWORD action, HWND wnd, UINT id, UINT version, UINT callbackmsg, HICON icon, const char* tip)
-{
-    NOTIFYICONDATA nid;
-    memset(&nid, 0, sizeof(nid));
-    nid.cbSize = NOTIFYICONDATA_V2_SIZE;
-    nid.hWnd = wnd;
-    nid.uID = id;
-    nid.uFlags = 0;
-    if (action & NIM_SETVERSION)
-        nid.uVersion = version;
-    if (callbackmsg) {
-        nid.uFlags |= NIF_MESSAGE;
-        nid.uCallbackMessage = callbackmsg;
-    }
-    if (icon) {
-        nid.uFlags |= NIF_ICON;
-        nid.hIcon = icon;
-    }
-    if (tip) {
-        nid.uFlags |= NIF_TIP;
-        _tcsncpy_s(nid.szTip, pfc::stringcvt::string_os_from_utf8(tip), tabsize(nid.szTip) - 1);
-    }
-
-    return run_action(action, &nid);
-}
-
-BOOL shell_notify_icon_ex(DWORD action, HWND wnd, UINT id, UINT callbackmsg, HICON icon, const char* tip,
-    const char* balloon_title, const char* balloon_msg)
-{
-    NOTIFYICONDATA nid;
-    memset(&nid, 0, sizeof(nid));
-    nid.cbSize = NOTIFYICONDATA_V2_SIZE;
-    nid.hWnd = wnd;
-    nid.uID = id;
-    if (callbackmsg) {
-        nid.uFlags |= NIF_MESSAGE;
-        nid.uCallbackMessage = callbackmsg;
-    }
-    if (icon) {
-        nid.uFlags |= NIF_ICON;
-        nid.hIcon = icon;
-    }
-    if (tip) {
-        nid.uFlags |= NIF_TIP;
-        _tcsncpy_s(nid.szTip, pfc::stringcvt::string_os_from_utf8(tip), tabsize(nid.szTip) - 1);
-    }
-
-    nid.dwInfoFlags = NIIF_INFO | NIIF_NOSOUND;
-    // if (balloon_title || balloon_msg)
-    {
-        nid.uFlags |= NIF_INFO;
-        if (balloon_title)
-            _tcsncpy_s(
-                nid.szInfoTitle, pfc::stringcvt::string_os_from_utf8(balloon_title), tabsize(nid.szInfoTitle) - 1);
-        if (balloon_msg)
-            _tcsncpy_s(nid.szInfo, pfc::stringcvt::string_os_from_utf8(balloon_msg), tabsize(nid.szInfo) - 1);
-    }
-    return run_action(action, reinterpret_cast<NOTIFYICONDATA*>(&nid));
-}
 int combo_box_add_string_data(HWND wnd, const TCHAR* str, LPARAM data)
 {
     int index = ComboBox_AddString(wnd, str);
@@ -492,16 +387,6 @@ BOOL tooltip_add_tool(HWND wnd, const LPTOOLINFO pti)
 BOOL tooltip_update_tip_text(HWND wnd, const LPTOOLINFO pti)
 {
     return static_cast<BOOL>(SendMessage(wnd, TTM_UPDATETIPTEXT, 0, reinterpret_cast<LPARAM>(pti)));
-}
-
-BOOL header_set_item_text(HWND wnd, int n, const wchar_t* text)
-{
-    HDITEM hdi;
-    memset(&hdi, 0, sizeof(hdi));
-    hdi.mask = HDI_TEXT;
-    hdi.cchTextMax = NULL;
-    hdi.pszText = const_cast<wchar_t*>(text);
-    return Header_SetItem(wnd, n, &hdi);
 }
 
 BOOL header_set_item_width(HWND wnd, int n, UINT cx)

--- a/win32_helpers.cpp
+++ b/win32_helpers.cpp
@@ -546,4 +546,32 @@ void enhance_edit_control(HWND wnd, int id)
     enhance_edit_control(GetDlgItem(wnd, id));
 }
 
+namespace {
+
+bool should_show_focus_indicator_on_keydown(WPARAM wp)
+{
+    if (wp < VK_BACK || wp == VK_LWIN || wp == VK_RWIN)
+        return false;
+
+    if (wp >= VK_VOLUME_MUTE && wp <= VK_LAUNCH_APP2)
+        return false;
+
+    return true;
+}
+
+} // namespace
+
+void show_focus_indicator(HWND wnd)
+{
+    SendMessage(wnd, WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), NULL);
+}
+
+void show_focus_indicator_on_keydown(HWND wnd, WPARAM wp)
+{
+    if (!should_show_focus_indicator_on_keydown(wp))
+        return;
+
+    show_focus_indicator(wnd);
+}
+
 } // namespace uih

--- a/win32_helpers.h
+++ b/win32_helpers.h
@@ -31,8 +31,6 @@ inline KeyboardLParam& GetKeyboardLParam(LPARAM& lp)
 bool are_keyboard_cues_enabled();
 bool is_high_contrast_active();
 
-BOOL set_process_dpi_aware();
-
 // This is cached as system-DPI changes take effect at next log on.
 // Per monitor-DPI changes can occur more frequently for per monitor-DPI aware applications.
 // At present, though, per-monitor DPI support is not declared by the foobar2000.exe manifest.
@@ -64,17 +62,10 @@ int combo_box_find_item_by_data(HWND wnd, size_t id);
 
 void rebar_show_all_bands(HWND wnd);
 
-BOOL shell_notify_icon(DWORD action, HWND wnd, UINT id, UINT version, UINT callbackmsg, HICON icon, const char* tip);
-BOOL shell_notify_icon_ex(DWORD action, HWND wnd, UINT id, UINT callbackmsg, HICON icon, const char* tip,
-    const char* balloon_title, const char* balloon_msg);
-
 BOOL tooltip_add_tool(HWND wnd, const LPTOOLINFO pti);
 BOOL tooltip_update_tip_text(HWND wnd, const LPTOOLINFO pti);
 
-BOOL header_set_item_text(HWND wnd, int n, const wchar_t* text);
 BOOL header_set_item_width(HWND wnd, int n, UINT cx);
-
-void format_date(uint64_t time, std::basic_string<TCHAR>& str, bool b_convert_to_local = false);
 
 void handle_modern_background_paint(HWND wnd, HWND wnd_button,
     HBRUSH top_background_brush = GetSysColorBrush(COLOR_WINDOW),

--- a/win32_helpers.h
+++ b/win32_helpers.h
@@ -146,4 +146,7 @@ public:
 void enhance_edit_control(HWND wnd);
 void enhance_edit_control(HWND wnd, int id);
 
+void show_focus_indicator(HWND wnd);
+void show_focus_indicator_on_keydown(HWND wnd, WPARAM wp);
+
 } // namespace uih


### PR DESCRIPTION
This stops the list view from showing hidden focus indicators when pressing multimedia keys, the Windows key and certain other keys.

It also adds some utility functions for the same functionality that can be used in other windows.

Lastly, some unused functions were removed.