### PR TITLE
Use separate font configuration for list view search bar

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -292,6 +292,7 @@ public:
     void set_font(std::optional<direct_write::TextFormat> text_format, const LOGFONT& log_font);
     void set_group_font(std::optional<direct_write::TextFormat> text_format);
     void set_header_font(std::optional<direct_write::TextFormat> text_format, const LOGFONT& log_font);
+    void set_search_bar_font(std::optional<direct_write::TextFormat> text_format, const LOGFONT& log_font);
 
     std::optional<float> get_group_font_size_pt() const;
     std::optional<float> get_items_font_size_pt() const;

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -898,12 +898,6 @@ void ListView::set_font(std::optional<direct_write::TextFormat> text_format, con
             update_header();
         }
 
-        if (m_search_bar) {
-            m_search_bar.invalidate();
-            m_search_bar.set_font(m_items_font.get());
-            m_search_bar.reposition();
-        }
-
         refresh_item_positions();
     }
 }
@@ -920,6 +914,15 @@ void ListView::set_header_font(std::optional<direct_write::TextFormat> text_form
         on_size();
     }
 }
+
+void ListView::set_search_bar_font(std::optional<direct_write::TextFormat> text_format, const LOGFONT& log_font)
+{
+    m_search_bar.set_font(std::move(text_format), log_font);
+
+    if (m_search_bar)
+        update_scroll_info();
+}
+
 std::optional<float> ListView::get_group_font_size_pt() const
 {
     if (!m_group_text_format)

--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -80,8 +80,7 @@ void ListView::render_items(HDC dc, const RECT& paint_rect)
     RECT items_paint_rect{};
 
     if (m_search_bar) {
-        const auto search_area_rect
-            = m_search_bar.render(dc, rc_items.right, rc_items.bottom, context.colours, m_items_text_format);
+        const auto search_area_rect = m_search_bar.render(dc, rc_items.right, rc_items.bottom, context.colours);
 
         SubtractRect(&items_paint_rect, &paint_rect, &search_area_rect);
         ExcludeClipRect(

--- a/list_view/list_view_search.cpp
+++ b/list_view/list_view_search.cpp
@@ -218,7 +218,7 @@ void SearchBar::create(HWND parent_wnd, const char* label, HFONT font, int item_
             return {};
         });
 
-    set_font(font);
+    update_edit_control_font();
     SetWindowTheme(m_edit_control.get(), is_dark ? L"DarkMode_Explorer" : nullptr, nullptr);
 
     Edit_SetCueBannerTextFocused(m_edit_control.get(), mmh::to_utf16(label).c_str(), true);
@@ -387,13 +387,20 @@ void SearchBar::set_use_dark_mode(bool is_dark)
         set_toolbar_dark_mode(m_right_toolbar, right_commands);
 }
 
-void SearchBar::set_font(HFONT font)
+void SearchBar::set_font(std::optional<direct_write::TextFormat> text_format, const LOGFONT& log_font)
 {
+    m_log_font = log_font;
+    m_text_format = std::move(text_format);
+
     if (!m_edit_control.get())
         return;
 
-    m_edit_height = get_font_height(font) + 2 * 3_spx;
-    SetWindowFont(m_edit_control.get(), font, FALSE);
+    invalidate();
+
+    update_edit_control_font();
+    RedrawWindow(m_edit_control.get(), nullptr, nullptr, RDW_INVALIDATE);
+
+    reposition();
 }
 
 void SearchBar::set_results_text(std::wstring_view new_text)
@@ -411,8 +418,7 @@ void SearchBar::invalidate() const
     RedrawWindow(m_parent_wnd, &invalidate_rect, nullptr, RDW_INVALIDATE);
 }
 
-RECT SearchBar::render(HDC dc, int items_width, int items_bottom, const ColourData& colours,
-    const std::optional<direct_write::TextFormat>& text_format)
+RECT SearchBar::render(HDC dc, int items_width, int items_bottom, const ColourData& colours) const
 {
     const auto metrics = get_metrics();
 
@@ -425,7 +431,7 @@ RECT SearchBar::render(HDC dc, int items_width, int items_bottom, const ColourDa
     PatBlt(dc, search_area_rect.left, search_area_rect.top, wil::rect_width(search_area_rect), metrics.total_height,
         PATCOPY);
 
-    if (!text_format)
+    if (!m_text_format)
         return search_area_rect;
 
     const auto horizontal_padding = get_horizontal_padding();
@@ -436,7 +442,7 @@ RECT SearchBar::render(HDC dc, int items_width, int items_bottom, const ColourDa
     if (text_available_width <= 0)
         return search_area_rect;
 
-    const auto text_layout = text_format->create_text_layout(m_results_text,
+    const auto text_layout = m_text_format->create_text_layout(m_results_text,
         direct_write::px_to_dip(static_cast<float>(text_available_width)),
         direct_write::px_to_dip(static_cast<float>(metrics.total_height)), true);
 
@@ -458,6 +464,17 @@ int SearchBar::get_horizontal_padding()
 int SearchBar::get_vertical_padding()
 {
     return 2_spx;
+}
+
+void SearchBar::update_edit_control_font()
+{
+    const auto _old_font = std::move(m_hfont);
+
+    if (m_log_font)
+        m_hfont.reset(CreateFontIndirect(&*m_log_font));
+
+    m_edit_height = get_font_height(m_hfont.get()) + 2 * 3_spx;
+    SetWindowFont(m_edit_control.get(), m_hfont.get(), FALSE);
 }
 
 } // namespace uih::lv

--- a/list_view/list_view_search.h
+++ b/list_view/list_view_search.h
@@ -91,18 +91,21 @@ public:
     void on_string_change();
 
     void set_use_dark_mode(bool is_dark);
-    void set_font(HFONT font);
+    void set_font(std::optional<direct_write::TextFormat> text_format, const LOGFONT& log_font);
 
     void set_results_text(std::wstring_view new_text);
     void invalidate() const;
-    RECT render(HDC dc, int items_width, int items_bottom, const ColourData& colours,
-        const std::optional<direct_write::TextFormat>& text_format);
+    RECT render(HDC dc, int items_width, int items_bottom, const ColourData& colours) const;
 
 private:
     static int get_horizontal_padding();
     static int get_vertical_padding();
+    void update_edit_control_font();
 
     bool m_is_initialising{};
+    std::optional<LOGFONT> m_log_font{};
+    wil::unique_hfont m_hfont;
+    std::optional<direct_write::TextFormat> m_text_format;
     wil::unique_hwnd m_edit_control;
     bool m_ignore_next_wm_char_message{};
     bool m_ignore_next_wm_syschar_message{};


### PR DESCRIPTION
This makes the list view search bar use a font that’s specified explicitly by the list view host, rather than just using the items font.