### PR TITLE
Prioritise host Ctrl+F handler in list view search bar

### DIFF
--- a/list_view/list_view_search.cpp
+++ b/list_view/list_view_search.cpp
@@ -176,6 +176,11 @@ void SearchBar::create(HWND parent_wnd, const char* label, HFONT font, int item_
                     m_search_bar_host->on_return();
                     return 0;
                 case 'F': {
+                    if (m_search_bar_host->on_keydown(wp)) {
+                        m_ignore_next_wm_char_message = true;
+                        return 0;
+                    }
+
                     const auto is_alt_down = (HIWORD(lp) & KF_ALTDOWN) != 0;
                     const auto is_ctrl_down = (GetKeyState(VK_CONTROL) & KF_UP) != 0;
                     const auto is_shift_down = (GetKeyState(VK_SHIFT) & KF_UP) != 0;


### PR DESCRIPTION
This updates the handling of F key down events in the list view search bar edit control to allow the host to override the handling of the key press.

This is mainly so that if the host has custom handling for Ctrl+F, it still gets invoked when the search bar edit control is focused.