### PR TITLE
Use more conventional Shift-select behaviour in list view

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -522,6 +522,7 @@ public:
     void set_selection_state(const pfc::bit_array& p_affected, const pfc::bit_array& p_status, bool b_notify = true,
         notification_source_t p_notification_source = notification_source_unknown);
     size_t get_focus_item();
+    std::optional<size_t> get_focus_item_optional();
     void set_focus_item(size_t index, bool b_notify = true);
     bool get_item_selected(size_t index);
 
@@ -1054,7 +1055,7 @@ private:
     int m_item_height{1};
     int m_group_height{1};
     bool m_are_group_headers_sticky{};
-    size_t m_shift_start{std::numeric_limits<size_t>::max()};
+    std::optional<size_t> m_shift_start;
     bool m_timer_scroll_up{false};
     bool m_timer_scroll_down{false};
     bool m_lbutton_down_ctrl{false};

--- a/list_view/list_view_item_state.cpp
+++ b/list_view/list_view_item_state.cpp
@@ -28,6 +28,14 @@ size_t ListView::get_focus_item()
     return ret;
 }
 
+std::optional<size_t> ListView::get_focus_item_optional()
+{
+    if (size_t index = storage_get_focus_item(); index < get_item_count())
+        return index;
+
+    return {};
+}
+
 void ListView::set_focus_item(size_t index, bool b_notify)
 {
     size_t old = storage_get_focus_item();
@@ -70,13 +78,16 @@ void ListView::set_item_selected(size_t index, bool b_state)
         set_selection_state(pfc::bit_array_one(index), pfc::bit_array_one(index));
     else
         set_selection_state(pfc::bit_array_one(index), pfc::bit_array_false());
+
+    m_shift_start.reset();
 }
+
 void ListView::set_item_selected_single(size_t index, bool b_notify, notification_source_t p_notification_source)
 {
     if (index < m_items.size()) {
         set_selection_state(pfc::bit_array_true(), pfc::bit_array_one(index), b_notify, p_notification_source);
         set_focus_item(index, b_notify);
-        // ensure_visible(index);
+        m_shift_start.reset();
     }
 }
 

--- a/list_view/list_view_items.cpp
+++ b/list_view/list_view_items.cpp
@@ -184,6 +184,8 @@ void ListView::remove_all_items()
 
 bool ListView::replace_items_in_internal_state(size_t index_start, size_t replace_count, const InsertItem* items)
 {
+    m_shift_start.reset();
+
     std::vector items_prev(m_items);
 
     const size_t total_items = m_items.size();
@@ -313,6 +315,8 @@ bool ListView::replace_items_in_internal_state(size_t index_start, size_t replac
 
 void ListView::insert_items_in_internal_state(size_t index_start, size_t insert_count, const InsertItem* items)
 {
+    m_shift_start.reset();
+
     const auto total_items = m_items.size();
     const auto old_group_display_count = index_start < total_items ? get_item_display_group_count(index_start) : 0;
 
@@ -565,6 +569,8 @@ void ListView::remove_items_in_internal_state(const pfc::bit_array& mask)
 
 void ListView::remove_item_in_internal_state(size_t remove_index)
 {
+    m_shift_start.reset();
+
     const size_t total_items = m_items.size();
     size_t old_group_display_count{};
 

--- a/list_view/list_view_keyboard.cpp
+++ b/list_view/list_view_keyboard.cpp
@@ -50,9 +50,9 @@ bool ListView::on_wm_keydown(WPARAM wp, LPARAM lp)
         return true;
     }
     case VK_SHIFT:
-        if (!(HIWORD(lp) & KF_REPEAT)) {
-            size_t focus = get_focus_item();
-            m_shift_start = focus != pfc_infinite ? focus : 0;
+        if (!(HIWORD(lp) & KF_REPEAT) && !m_shift_start && get_item_count() > 0) {
+            const auto focus = get_focus_item();
+            m_shift_start = focus != SIZE_MAX ? focus : 0;
         }
         return false;
     case VK_F2:

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -421,10 +421,13 @@ void ListView::process_navigation_keydown(WPARAM wp, bool alt_down, bool repeat)
         if ((GetKeyState(VK_SHIFT) & KF_UP) && (GetKeyState(VK_CONTROL) & KF_UP)) {
             // if (!repeat) playlist_api->activeplaylist_undo_backup();
             move_selection(target_item - focus);
+            m_shift_start.reset();
         } else if ((GetKeyState(VK_CONTROL) & KF_UP)) {
             set_focus_item(target_item);
         } else if (m_selection_mode == SelectionMode::Multiple && (GetKeyState(VK_SHIFT) & KF_UP)) {
-            const size_t start = m_alternate_selection ? focus : m_shift_start;
+            if (!m_shift_start)
+                m_shift_start = focus;
+            const size_t start = m_alternate_selection ? focus : *m_shift_start;
             const pfc::bit_array_range array_select(
                 std::min(start, size_t(target_item)), abs(int(start - (target_item))) + 1);
             if (m_alternate_selection && !is_focus_selected)

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -209,13 +209,17 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             }
             else */
             if (b_shift_down && m_selection_mode == SelectionMode::Multiple) {
-                size_t focus = get_focus_item();
-                size_t start = m_alternate_selection ? focus : m_shift_start;
+                const auto focus_index = get_focus_item_optional();
+
+                if (!m_alternate_selection && !m_shift_start)
+                    m_shift_start = focus_index.value_or(0);
+
+                size_t start = m_alternate_selection ? focus_index.value_or(0) : *m_shift_start;
                 pfc::bit_array_range br(std::min(start, hit_result.index), abs(t_ssize(start - hit_result.index)) + 1);
                 if (m_lbutton_down_ctrl && !m_alternate_selection) {
                     set_selection_state(br, br, true);
                 } else {
-                    if (m_alternate_selection && !get_item_selected(focus))
+                    if (m_alternate_selection && (!focus_index || !get_item_selected(*focus_index)))
                         set_selection_state(br, pfc::bit_array_not(br), true);
                     else if (m_alternate_selection)
                         set_selection_state(br, br, true);
@@ -240,6 +244,8 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         } else if (hit_result.category == HitTestCategory::OnGroupHeader) {
             if (m_selection_mode == SelectionMode::Multiple) {
                 if (!m_lbutton_down_ctrl) {
+                    m_shift_start.reset();
+
                     const auto [index, count] = get_item_group_range(hit_result.index, hit_result.group_level);
 
                     if (!hit_result.is_stuck || b_shift_down)
@@ -252,8 +258,10 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 }
             }
         } else if (hit_result.category != HitTestCategory::BelowViewport) {
-            if (m_selection_mode != SelectionMode::SingleStrict)
+            if (m_selection_mode != SelectionMode::SingleStrict) {
                 set_selection_state(pfc::bit_array_true(), pfc::bit_array_false());
+                m_shift_start.reset();
+            }
         }
     }
         return 0;
@@ -295,6 +303,8 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     }
                 } else if (hit_result.category == HitTestCategory::OnGroupHeader) {
                     if (hit_result.index < m_items.size() && hit_result.group_level < m_group_count) {
+                        m_shift_start.reset();
+
                         const auto [index, count] = get_item_group_range(hit_result.index, hit_result.group_level);
 
                         if (count > 0) {
@@ -350,12 +360,15 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             const auto [index, count] = get_item_group_range(hit_result.index, hit_result.group_level);
             const auto is_selected = is_range_selected(index, count);
 
-            if (!is_selected)
+            if (!is_selected) {
+                m_shift_start.reset();
                 set_selection_state(pfc::bit_array_true(), pfc::bit_array_range(index, count));
+            }
 
             set_focus_item(index);
         } else if (hit_result.category != HitTestCategory::BelowViewport
             && m_selection_mode != SelectionMode::SingleStrict) {
+            m_shift_start.reset();
             set_selection_state(pfc::bit_array_true(), pfc::bit_array_false());
         }
         break;
@@ -450,6 +463,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                             set_selection_state(pfc::bit_array_true(),
                                 pfc::bit_array_range(std::min(target_index, m_selecting_start), num_to_select));
                             set_focus_item(target_index);
+                            m_shift_start.reset();
                         }
                     }
                 }


### PR DESCRIPTION
This makes the list view remember the start position when Shift-selecting (either using the mouse or the keyboard) if the Shift key is released between clicks or arrow key presses. This behaviour is more in line with File Explorer and other list views.

The Shift-selection starting position is now reset on certain other events, such as clicking on an item or inserting or removing items.