### PR TITLE
Reset list view Shift-select starting point on Ctrl+Up/Down

### DIFF
--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -424,6 +424,7 @@ void ListView::process_navigation_keydown(WPARAM wp, bool alt_down, bool repeat)
             m_shift_start.reset();
         } else if ((GetKeyState(VK_CONTROL) & KF_UP)) {
             set_focus_item(target_item);
+            m_shift_start.reset();
         } else if (m_selection_mode == SelectionMode::Multiple && (GetKeyState(VK_SHIFT) & KF_UP)) {
             if (!m_shift_start)
                 m_shift_start = focus;


### PR DESCRIPTION
This makes the list view reset the starting position for Shift-selecting when changing the focused item using Ctrl+Up or Ctrl+Down.

This is because Shift-selecting uses the focused item as a starting point, so intentionally changing it should reset the starting point. (This is in line with Default UI list views in foobar2000.)