### PR TITLE
Correct trackbar tooltip positioning in different scenarios

### DIFF
--- a/trackbar_base.cpp
+++ b/trackbar_base.cpp
@@ -2,6 +2,8 @@
 
 namespace uih {
 
+using namespace literals::spx;
+
 BOOL TrackbarBase::create_tooltip(const TCHAR* text, POINT pt)
 {
     destroy_tooltip();
@@ -24,7 +26,7 @@ BOOL TrackbarBase::create_tooltip(const TCHAR* text, POINT pt)
 
     tooltip_add_tool(m_wnd_tooltip, &ti);
 
-    m_cursor_height = get_pointer_height();
+    m_cursor_height = get_arrow_pointer_height() + 3_spx;
 
     SendMessage(m_wnd_tooltip, TTM_TRACKPOSITION, 0, MAKELONG(pt.x, pt.y + m_cursor_height));
     SendMessage(m_wnd_tooltip, TTM_TRACKACTIVATE, TRUE, reinterpret_cast<LPARAM>(&ti));

--- a/win32_helpers.cpp
+++ b/win32_helpers.cpp
@@ -173,47 +173,57 @@ int scale_dpi_value(int value, unsigned original_dpi)
     return MulDiv(value, get_system_dpi_cached().cx, original_dpi);
 }
 
-int get_pointer_height()
+int get_arrow_pointer_height()
 {
-    int win_10_pointer_size{};
-    if (SystemParametersInfo(SPI_GET_POINTER_SCALE, 0, &win_10_pointer_size, 0) && win_10_pointer_size > 0)
-        return win_10_pointer_size;
+    const auto base_pointer_size = GetSystemMetrics(SM_CYCURSOR);
+
+    int pointer_scale{32};
+    SystemParametersInfo(SPI_GET_POINTER_SCALE, 0, &pointer_scale, 0);
+
+    const auto pointer_size = MulDiv(base_pointer_size, pointer_scale, 32);
+
+    BITMAPINFOHEADER bmi{};
+
+    bmi.biSize = sizeof(bmi);
+    bmi.biWidth = pointer_size;
+    bmi.biHeight = -pointer_size;
+    bmi.biPlanes = 1;
+    bmi.biBitCount = 32;
+    bmi.biCompression = BI_RGB;
+    bmi.biClrUsed = 0;
+    bmi.biClrImportant = 0;
+
+    std::array<uint8_t, sizeof(BITMAPINFOHEADER)> bm_data{};
+
+    auto* bi = reinterpret_cast<BITMAPINFO*>(bm_data.data());
+    bi->bmiHeader = bmi;
+
+    void* bitmap_data{};
+    const wil::unique_hbitmap bitmap(CreateDIBSection(nullptr, bi, DIB_RGB_COLORS, &bitmap_data, nullptr, 0));
+
+    if (!bitmap || !bitmap_data)
+        return pointer_size;
+
+    const auto bitmap_data_u32 = static_cast<uint32_t*>(bitmap_data);
+
+    const auto desktop_dc = wil::GetDC(nullptr);
+    wil::unique_hdc memory_dc(CreateCompatibleDC(desktop_dc.get()));
+    const auto _ = wil::SelectObject(memory_dc.get(), bitmap.get());
 
     const auto cursor
         = static_cast<HCURSOR>(LoadImage(nullptr, IDC_ARROW, IMAGE_CURSOR, 0, 0, LR_DEFAULTSIZE | LR_SHARED));
 
-    ICONINFO icon_info{};
-    if (!GetIconInfo(cursor, &icon_info))
-        return 0;
+    DrawIconEx(memory_dc.get(), 0, 0, cursor, pointer_size, pointer_size, 0, nullptr, DI_NORMAL);
 
-    const wil::unique_hbitmap _colour_bitmap(icon_info.hbmColor);
-    const wil::unique_hbitmap _mask_bitmap(icon_info.hbmMask);
-
-    if (!icon_info.hbmMask)
-        return 0;
-
-    BITMAP bitmap_info{};
-    if (!GetObject(icon_info.hbmMask, sizeof(BITMAP), &bitmap_info))
-        return 0;
-
-    const auto bitmap_height = gsl::narrow<int>(icon_info.hbmColor ? bitmap_info.bmHeight : bitmap_info.bmHeight / 2);
-    const auto bitmap_width = gsl::narrow<int>(bitmap_info.bmWidth);
-
-    const wil::unique_hdc_window desktop_dc(GetDC(nullptr));
-    const wil::unique_hdc memory_dc(CreateCompatibleDC(desktop_dc.get()));
-    auto _ = wil::SelectObject(memory_dc.get(), icon_info.hbmMask);
-
-    for (auto y : ranges::views::iota(0, bitmap_height) | ranges::views::reverse) {
-        const auto any_pixel_set = ranges::any_of(ranges::views::iota(0, bitmap_width), [&memory_dc, y](auto x) {
-            const auto colour = GetPixel(memory_dc.get(), x, y);
-            return colour != 0xFFFFFF;
-        });
+    for (auto y : ranges::views::iota(0, pointer_size) | ranges::views::reverse) {
+        const auto any_pixel_set = ranges::any_of(
+            ranges::views::iota(0, pointer_size), [&](auto x) { return bitmap_data_u32[y * pointer_size + x] != 0; });
 
         if (any_pixel_set)
-            return y + 1 - gsl::narrow<int>(icon_info.yHotspot);
+            return y + 1;
     }
 
-    return 0;
+    return pointer_size;
 }
 
 int combo_box_add_string_data(HWND wnd, const TCHAR* str, LPARAM data)

--- a/win32_helpers.h
+++ b/win32_helpers.h
@@ -40,7 +40,7 @@ int scale_dpi_value(int value, unsigned original_dpi = USER_DEFAULT_SCREEN_DPI);
 
 constexpr auto SPI_GET_POINTER_SCALE = 0x2028;
 constexpr auto SPI_SET_POINTER_SCALE = 0x2029;
-int get_pointer_height();
+int get_arrow_pointer_height();
 
 void list_view_set_explorer_theme(HWND wnd);
 int list_view_insert_column_text(HWND wnd_lv, int index, const TCHAR* text, int cx);


### PR DESCRIPTION
This corrects the logic to calculate the rendered height of the arrow pointer to handle different display scales and Windows 10 and 11 pointer sizes correctly.

The previous logic did not handle the Windows 10 and newer pointer size setting correctly, causing trackbar tooltips to be positioned incorrectly in most cases.

The new logic does not account for the pointer hotspot, as there doesn’t seem to be a simple way to query it while accounting for pointer scaling.

However, it's normally (0, 0) for the standard arrow pointer anyway. (Even if it isn’t, it just means that the tooltip will just be positioned a bit further away.)