### PR TITLE
Add focus option to autoscroll helper

### DIFF
--- a/autoscroll.cpp
+++ b/autoscroll.cpp
@@ -29,7 +29,7 @@ void update_overlay_window(HWND overlay_wnd, POINT screen_pt, const AutoscrollHe
 
 } // namespace
 
-void AutoscrollHelper::start(HWND wnd)
+void AutoscrollHelper::start(HWND wnd, bool set_focus)
 {
     if (m_active)
         return;
@@ -45,6 +45,7 @@ void AutoscrollHelper::start(HWND wnd)
     m_wnd = wnd;
     m_has_scrolled = false;
     m_active = true;
+    m_previously_focused_wnd = set_focus ? SetFocus(wnd) : nullptr;
 
     // Note: WM_MBUTTONDOWN and WM_MBUTTONUP give the wrong pointer position if a popup menu was open
     const auto message_pos = GetMessagePos();
@@ -337,6 +338,9 @@ void AutoscrollHelper::stop()
         m_overlay_window->destroy();
         m_overlay_window.reset();
     }
+
+    if (m_previously_focused_wnd)
+        SetFocus(IsWindow(m_previously_focused_wnd) ? m_previously_focused_wnd : GetAncestor(m_wnd, GA_ROOT));
 }
 
 } // namespace uih

--- a/autoscroll.h
+++ b/autoscroll.h
@@ -38,7 +38,7 @@ public:
     {
     }
 
-    void start(HWND wnd);
+    void start(HWND wnd, bool set_focus = false);
 
     std::optional<LRESULT> handle_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
@@ -61,6 +61,7 @@ private:
     bool m_is_dark{};
     ScrollCallback m_scroll_callback{};
     HWND m_wnd{};
+    HWND m_previously_focused_wnd{};
     bool m_active{};
     bool m_can_scroll_vertically{};
     bool m_can_scroll_horizontally{};


### PR DESCRIPTION
This adds an option to the autoscroll helper to make it temporarily focus the window being scrolled.

This is so that the Esc key can be used to stop autoscrolling even if the window doesn’t normally take focus.