### PR TITLE
Add detection of group info area to list view hit testing

### DIFF
--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -487,7 +487,7 @@ public:
 
     int get_group_minimum_inner_height() const
     {
-        return get_show_group_info_area() && m_visible_group_count > 0 ? get_group_info_area_total_height() : 0;
+        return get_show_group_info_area() ? get_group_info_area_total_height() : 0;
     }
     int get_group_items_bottom_margin(size_t index) const;
     int get_leaf_group_header_bottom_margin(std::optional<size_t> index = {}) const;
@@ -509,7 +509,7 @@ public:
 
         int ret = get_item_position(index) + m_item_height - 1;
 
-        if (get_show_group_info_area() && m_visible_group_count > 0) {
+        if (get_show_group_info_area()) {
             int gheight = gsl::narrow<int>(group_size) * m_item_height;
             int group_cy = get_group_info_area_total_height();
             const auto bottom_margin = get_group_items_bottom_margin(index);
@@ -799,7 +799,7 @@ protected:
         return header_item_index - 1;
     }
 
-    bool get_show_group_info_area() const { return m_group_count > 0 ? m_show_group_info_area : false; }
+    bool get_show_group_info_area() const { return m_visible_group_count > 0 ? m_show_group_info_area : false; }
 
     int get_total_indentation() const;
     [[nodiscard]] int get_stuck_group_headers_height(std::optional<int> scroll_position = {}) const;

--- a/list_view/list_view.h
+++ b/list_view/list_view.h
@@ -169,6 +169,7 @@ public:
         OnItemObscuredBelow,
         LeftOfItem,
         RightOfItem,
+        OnGroupInfoArea,
         OnGroupHeader,
         LeftOfGroupHeader,
         RightOfGroupHeader,
@@ -337,7 +338,9 @@ public:
     void remove_items(const pfc::bit_array& mask);
     void remove_all_items();
 
+    HitTestResult hit_test_ex(POINT pt_client, bool exclude_stuck_headers = false);
     void hit_test_ex(POINT pt_client, HitTestResult& result, bool exclude_stuck_headers = false);
+
     void update_scroll_info(bool b_vertical = true, bool b_horizontal = true, bool redraw = true,
         std::optional<int> new_vertical_position = std::nullopt);
     ItemVisibility get_item_visibility(size_t index, bool use_target_position = true) const;

--- a/list_view/list_view_hittest.cpp
+++ b/list_view/list_view_hittest.cpp
@@ -4,12 +4,14 @@
 
 namespace uih {
 
-void ListView::hit_test_ex(POINT pt_client, HitTestResult& result, bool exclude_stuck_headers)
+ListView::HitTestResult ListView::hit_test_ex(POINT pt_client, bool exclude_stuck_headers)
 {
     const RECT rc_item_area = get_items_rect();
     const int item_area_height = RECT_CY(rc_item_area);
 
+    HitTestResult result{};
     result.column = pfc_infinite;
+
     const int first_column_left = -m_horizontal_scroll_position + get_total_indentation();
     const size_t column_count = m_columns.size();
     int last_column_right = first_column_left;
@@ -28,21 +30,48 @@ void ListView::hit_test_ex(POINT pt_client, HitTestResult& result, bool exclude_
         result.index = get_first_unobscured_item(false);
         result.insertion_index = result.index;
         result.category = HitTestCategory::AboveViewport;
-        return;
+        return result;
     }
 
     if (pt_client.y >= rc_item_area.bottom) {
         result.index = get_last_unobscured_item(false);
         result.insertion_index = result.index;
         result.category = HitTestCategory::BelowViewport;
-        return;
+        return result;
     }
 
     const int header_height = rc_item_area.top;
     const int y_position = pt_client.y - header_height + m_scroll_position;
     const auto vertical_hit_test_result = visible_items_vertical_hit_test(y_position);
+    const auto vertical_category = vertical_hit_test_result.position_category;
 
-    if (vertical_hit_test_result.position_category == VerticalPositionCategory::OnItem) {
+    if (pt_client.x < first_column_left && get_show_group_info_area()
+        && (vertical_category == VerticalPositionCategory::OnItem
+            || vertical_category == VerticalPositionCategory::BetweenItems)) {
+        const auto group_info_area_rect
+            = get_item_group_info_area_render_rect(vertical_hit_test_result.item_leftmost, rc_item_area);
+
+        if (PtInRect(&group_info_area_rect, pt_client)) {
+            result.category = HitTestCategory::OnGroupInfoArea;
+            result.index = vertical_hit_test_result.item_leftmost;
+
+            result.insertion_index = [&] {
+                if (vertical_category == VerticalPositionCategory::OnItem) {
+                    const int item_top = get_item_position(vertical_hit_test_result.item_leftmost);
+                    const int item_height = get_item_height(vertical_hit_test_result.item_leftmost);
+
+                    if (item_height >= 2 && y_position - item_top >= item_height / 2)
+                        return vertical_hit_test_result.item_leftmost + 1;
+                }
+
+                return vertical_hit_test_result.item_leftmost;
+            }();
+
+            return result;
+        }
+    }
+
+    if (vertical_category == VerticalPositionCategory::OnItem) {
         const int item_top = get_item_position(vertical_hit_test_result.item_leftmost);
         const int item_bottom = get_item_position_bottom(vertical_hit_test_result.item_leftmost);
         const int item_height = get_item_height(result.index);
@@ -64,10 +93,10 @@ void ListView::hit_test_ex(POINT pt_client, HitTestResult& result, bool exclude_
         if (item_height >= 2 && y_position - item_top >= item_height / 2)
             result.insertion_index++;
 
-        return;
+        return result;
     }
 
-    if (vertical_hit_test_result.position_category == VerticalPositionCategory::BetweenGroupHeaderAndItem) {
+    if (vertical_category == VerticalPositionCategory::BetweenGroupHeaderAndItem) {
         assert(m_group_count > 0);
 
         const auto item_index = vertical_hit_test_result.item_leftmost;
@@ -76,10 +105,10 @@ void ListView::hit_test_ex(POINT pt_client, HitTestResult& result, bool exclude_
         result.insertion_index
             = vertical_hit_test_result.is_on_stuck_group_header ? get_first_unobscured_item(false) : item_index;
         result.category = HitTestCategory::NotOnItem;
-        return;
+        return result;
     }
 
-    if (vertical_hit_test_result.position_category == VerticalPositionCategory::OnGroupHeader) {
+    if (vertical_category == VerticalPositionCategory::OnGroupHeader) {
         assert(m_group_count > 0);
 
         result.category = HitTestCategory::OnGroupHeader;
@@ -97,12 +126,19 @@ void ListView::hit_test_ex(POINT pt_client, HitTestResult& result, bool exclude_
 
         result.is_stuck = vertical_hit_test_result.is_on_stuck_group_header;
 
-        return;
+        return result;
     }
 
     result.index = vertical_hit_test_result.item_leftmost;
     result.insertion_index = vertical_hit_test_result.item_rightmost;
     result.category = HitTestCategory::NotOnItem;
+
+    return result;
+}
+
+void ListView::hit_test_ex(POINT pt_client, HitTestResult& result, bool exclude_stuck_headers)
+{
+    result = hit_test_ex(pt_client, exclude_stuck_headers);
 }
 
 ListView::ItemVisibility ListView::get_item_visibility(size_t index, bool use_target_position) const

--- a/list_view/list_view_misc.cpp
+++ b/list_view/list_view_misc.cpp
@@ -16,8 +16,7 @@ void ListView::on_first_show()
 
 int ListView::get_group_items_bottom_margin(size_t index) const
 {
-    if (!get_show_group_info_area() || !m_is_group_info_area_header_spacing_enabled || m_visible_group_count == 0
-        || index + 1 == m_items.size())
+    if (!get_show_group_info_area() || !m_is_group_info_area_header_spacing_enabled || index + 1 == m_items.size())
         return 0;
 
     return m_group_height / 6;
@@ -25,7 +24,7 @@ int ListView::get_group_items_bottom_margin(size_t index) const
 
 int ListView::get_leaf_group_header_bottom_margin(std::optional<size_t> index) const
 {
-    if (!get_show_group_info_area() || !m_is_group_info_area_header_spacing_enabled || m_visible_group_count == 0)
+    if (!get_show_group_info_area() || !m_is_group_info_area_header_spacing_enabled)
         return 0;
 
     if (index && !get_is_new_group(*index))
@@ -44,7 +43,7 @@ int ListView::get_stuck_leaf_group_header_bottom_margin() const
 
 ListView::GroupInfoAreaPadding ListView::get_group_info_area_padding() const
 {
-    if (!get_show_group_info_area() || m_visible_group_count == 0)
+    if (!get_show_group_info_area())
         return {};
 
     const auto min_left_padding = 2_spx + 3_spx;
@@ -522,7 +521,7 @@ void ListView::invalidate_items(size_t index, size_t count) const
         return;
 
     const auto items_rect = get_items_rect();
-    const auto has_group_info_area = get_show_group_info_area() && m_visible_group_count > 0;
+    const auto has_group_info_area = get_show_group_info_area();
 
     const auto items_left
         = has_group_info_area ? get_total_indentation() - m_horizontal_scroll_position : items_rect.left;
@@ -582,7 +581,7 @@ void ListView::set_is_group_info_area_sticky(bool group_info_area_sticky)
     size_t first_item_index{};
     bool is_invalidation_needed{};
 
-    if (m_initialised && get_show_group_info_area() && m_visible_group_count > 0) {
+    if (m_initialised && get_show_group_info_area()) {
         first_item_index = gsl::narrow_cast<size_t>(get_first_or_previous_visible_item());
 
         if (first_item_index < m_items.size()) {
@@ -612,7 +611,7 @@ void ListView::set_is_group_info_area_header_spacing_enabled(bool value)
 RECT ListView::get_item_group_info_area_render_rect(
     size_t index, const std::optional<RECT>& items_rect, std::optional<int> scroll_position)
 {
-    if (!get_show_group_info_area() || m_visible_group_count == 0) {
+    if (!get_show_group_info_area()) {
         assert(false);
         return {};
     }

--- a/list_view/list_view_msgproc.cpp
+++ b/list_view/list_view_msgproc.cpp
@@ -193,8 +193,8 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         exit_inline_edit();
         SetFocus(wnd);
         POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
-        HitTestResult hit_result;
-        hit_test_ex(pt, hit_result);
+
+        const auto hit_result = hit_test_ex(pt);
         m_lbutton_down_hittest = hit_result;
         bool b_shift_down = (wp & MK_SHIFT) != 0;
         m_lbutton_down_ctrl = (wp & MK_CONTROL) != 0 && m_selection_mode == SelectionMode::Multiple; // Cheat.
@@ -341,8 +341,8 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         SetFocus(wnd);
 
         POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
-        HitTestResult hit_result;
-        hit_test_ex(pt, hit_result);
+        const auto hit_result = hit_test_ex(pt);
+
         if (hit_result.category == HitTestCategory::OnUnobscuredItem
             || hit_result.category == HitTestCategory::OnItemObscuredBelow
             || hit_result.category == HitTestCategory::OnItemObscuredAbove) {
@@ -412,20 +412,18 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (m_selecting && m_selection_mode == SelectionMode::Multiple) {
             // size_t index;
             if (!m_selecting_move) {
-                HitTestResult hit_result;
-                hit_test_ex(pt, hit_result, true);
+                const auto hit_result = hit_test_ex(pt, true);
                 {
                     if (hit_result.category == HitTestCategory::AboveViewport
                         || hit_result.category == HitTestCategory::BelowViewport
                         || hit_result.category == HitTestCategory::OnUnobscuredItem
-                        //|| hit_result.result == hit_test_obscured_below || hit_result.result ==
-                        // hit_test_obscured_above
                         || hit_result.category == HitTestCategory::RightOfItem
                         || hit_result.category == HitTestCategory::LeftOfItem
                         || hit_result.category == HitTestCategory::RightOfGroupHeader
                         || hit_result.category == HitTestCategory::LeftOfGroupHeader
                         || hit_result.category == HitTestCategory::NotOnItem
-                        || hit_result.category == HitTestCategory::OnGroupHeader) {
+                        || hit_result.category == HitTestCategory::OnGroupHeader
+                        || hit_result.category == HitTestCategory::OnGroupInfoArea) {
                         if (hit_result.category == HitTestCategory::BelowViewport) {
                             create_timer_scroll_down();
                         } else
@@ -477,8 +475,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     }
     case WM_LBUTTONDBLCLK: {
         POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
-        HitTestResult hit_result;
-        hit_test_ex(pt, hit_result);
+        const auto hit_result = hit_test_ex(pt);
 
         const auto is_shift_down = (wp & MK_SHIFT) != 0;
         const auto is_ctrl_down = (wp & MK_CONTROL) != 0;
@@ -521,8 +518,7 @@ LRESULT ListView::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_MBUTTONUP: {
         m_inline_edit_prevent = false;
         POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
-        HitTestResult hit_result;
-        hit_test_ex(pt, hit_result);
+        const auto hit_result = hit_test_ex(pt);
 
         if (hit_result.category != HitTestCategory::BelowViewport)
             notify_on_middleclick(hit_result.category == HitTestCategory::OnUnobscuredItem, hit_result.index);

--- a/list_view/list_view_renderer.cpp
+++ b/list_view/list_view_renderer.cpp
@@ -100,7 +100,7 @@ void ListView::render_items(HDC dc, const RECT& paint_rect)
     const auto item_indentation = get_total_indentation();
     const auto cx = get_columns_display_width() + item_indentation;
 
-    bool b_show_group_info_area = get_show_group_info_area() && m_visible_group_count > 0;
+    bool b_show_group_info_area = get_show_group_info_area();
 
     i = gsl::narrow<size_t>(get_item_at_or_before(
         (items_paint_rect.top > rc_items.top ? items_paint_rect.top - rc_items.top : 0) + m_scroll_position));

--- a/list_view/list_view_scroll.cpp
+++ b/list_view/list_view_scroll.cpp
@@ -147,7 +147,7 @@ void ListView::internal_scroll(int new_position, ScrollAxis axis)
 
     std::vector<RECT> invalidate_after_scroll_window{};
 
-    if (m_visible_group_count > 0 && get_show_group_info_area() && m_is_group_info_area_sticky && dy != 0) {
+    if (get_show_group_info_area() && m_is_group_info_area_sticky && dy != 0) {
         const auto first_items
             = std::unordered_set{gsl::narrow_cast<size_t>(get_first_or_previous_visible_item(original_scroll_position)),
                 gsl::narrow_cast<size_t>(get_first_or_previous_visible_item(m_scroll_position))};

--- a/list_view/list_view_tooltip.cpp
+++ b/list_view/list_view_tooltip.cpp
@@ -214,8 +214,7 @@ void ListView::handle_mousemove_for_tooltip(POINT pt)
     if (pt.y < get_items_top())
         return;
 
-    HitTestResult hit_result;
-    hit_test_ex(pt, hit_result);
+    const auto hit_result = hit_test_ex(pt);
 
     if (!(hit_result.category == HitTestCategory::OnUnobscuredItem
             || hit_result.category == HitTestCategory::OnItemObscuredBelow


### PR DESCRIPTION
This adds detection of the group info area to the main list view hit-testing function.

It also updates the `ListView::get_show_group_info_area()` method to check the visible group count rather than the total group count. This is more in line with how the method is used and avoids having to check the visible group count separately every time the method is called.