### PR TITLE
Remove Windows Vista and 7 version checks

### DIFF
--- a/ole.cpp
+++ b/ole.cpp
@@ -115,29 +115,22 @@ HRESULT set_blob(IDataObject* pdtobj, CLIPFORMAT cf, const void* pvBlob, UINT cb
 
 HRESULT set_drop_description(IDataObject* pdtobj, DROPIMAGETYPE dit, const char* msg, const char* insert)
 {
-    if (mmh::is_windows_vista_or_newer()) {
-        DROPDESCRIPTION dd_prev;
-        memset(&dd_prev, 0, sizeof(dd_prev));
+    DROPDESCRIPTION dd_prev{};
+    bool dd_prev_valid = SUCCEEDED(GetDataObjectDataSimple(pdtobj, get_clipboard_format_drop_description(), dd_prev));
 
-        bool dd_prev_valid
-            = (SUCCEEDED(GetDataObjectDataSimple(pdtobj, get_clipboard_format_drop_description(), dd_prev)));
+    pfc::stringcvt::string_os_from_utf8 wmsg(msg);
+    pfc::stringcvt::string_os_from_utf8 winsert(insert);
 
-        pfc::stringcvt::string_os_from_utf8 wmsg(msg);
-        pfc::stringcvt::string_os_from_utf8 winsert(insert);
-
-        // Only set the drop description if it has actually changed (otherwise things get a bit crazy near the edge of
-        // the screen).
-        if (!dd_prev_valid || dd_prev.type != dit || wcscmp(dd_prev.szInsert, winsert)
-            || wcscmp(dd_prev.szMessage, wmsg)) {
-            DROPDESCRIPTION dd;
-            dd.type = dit;
-            wcsncpy_s(dd.szMessage, wmsg.get_ptr(), _TRUNCATE);
-            wcsncpy_s(dd.szInsert, winsert.get_ptr(), _TRUNCATE);
-            return set_blob(pdtobj, get_clipboard_format_drop_description(), &dd, sizeof(dd));
-        }
-        return S_OK;
+    // Only set the drop description if it has actually changed (otherwise things get a bit crazy near the edge of
+    // the screen).
+    if (!dd_prev_valid || dd_prev.type != dit || wcscmp(dd_prev.szInsert, winsert) || wcscmp(dd_prev.szMessage, wmsg)) {
+        DROPDESCRIPTION dd;
+        dd.type = dit;
+        wcsncpy_s(dd.szMessage, wmsg.get_ptr(), _TRUNCATE);
+        wcsncpy_s(dd.szInsert, winsert.get_ptr(), _TRUNCATE);
+        return set_blob(pdtobj, get_clipboard_format_drop_description(), &dd, sizeof(dd));
     }
-    return E_NOTIMPL;
+    return S_OK;
 }
 
 HRESULT set_using_default_drag_image(IDataObject* pdtobj, BOOL value)

--- a/win32_helpers.cpp
+++ b/win32_helpers.cpp
@@ -9,15 +9,9 @@ const RECT rect_null = {0, 0, 0, 0};
 
 void list_view_set_explorer_theme(HWND wnd)
 {
-    if (mmh::is_windows_vista_or_newer()) {
-        ListView_SetExtendedListViewStyleEx(wnd, 0x00010000 | LVS_EX_FULLROWSELECT, 0x00010000 | LVS_EX_FULLROWSELECT);
-        if (mmh::is_windows_7_or_newer()) {
-            SetWindowTheme(wnd, L"ItemsView", nullptr);
-            // SetWindowTheme(ListView_GetHeader (wnd), L"ItemsView", NULL);
-        } else {
-            SetWindowTheme(wnd, L"Explorer", nullptr);
-        }
-    }
+    ListView_SetExtendedListViewStyleEx(
+        wnd, LVS_EX_DOUBLEBUFFER | LVS_EX_FULLROWSELECT, LVS_EX_DOUBLEBUFFER | LVS_EX_FULLROWSELECT);
+    SetWindowTheme(wnd, L"ItemsView", nullptr);
 }
 
 bool are_keyboard_cues_enabled()
@@ -37,17 +31,14 @@ bool is_high_contrast_active()
 
 void tree_view_set_explorer_theme(HWND wnd, bool b_reduce_indent)
 {
-    if (mmh::is_windows_vista_or_newer()) {
-        UINT_PTR stylesex = TVS_EX_DOUBLEBUFFER | TVS_EX_AUTOHSCROLL;
-        UINT_PTR styles = NULL;
+    UINT_PTR stylesex = TVS_EX_DOUBLEBUFFER | TVS_EX_AUTOHSCROLL;
 
-        SendMessage(wnd, TVM_SETEXTENDEDSTYLE, stylesex, stylesex);
-        SetWindowTheme(wnd, L"Explorer", nullptr);
-        SetWindowLongPtr(
-            wnd, GWL_STYLE, (GetWindowLongPtr(wnd, GWL_STYLE) & ~(TVS_HASLINES /*|TVS_NOHSCROLL*/)) | styles);
-        if (b_reduce_indent)
-            TreeView_SetIndent(wnd, 0xa);
-    }
+    SendMessage(wnd, TVM_SETEXTENDEDSTYLE, stylesex, stylesex);
+    SetWindowTheme(wnd, L"Explorer", nullptr);
+    SetWindowLongPtr(wnd, GWL_STYLE, GetWindowLongPtr(wnd, GWL_STYLE) & ~TVS_HASLINES);
+
+    if (b_reduce_indent)
+        TreeView_SetIndent(wnd, 0xa);
 }
 
 int list_view_insert_column_text(HWND wnd_lv, int index, const TCHAR* text, int cx)


### PR DESCRIPTION
This removes all remaining Windows Vista and Windows 7 version checks as these are no longer required.